### PR TITLE
Bunch of renaming and cleanup

### DIFF
--- a/example/src/functions.rs
+++ b/example/src/functions.rs
@@ -1,4 +1,4 @@
-use cel_interpreter::{Context, FunctionCtx, Program, ResolveResult};
+use cel_interpreter::{Context, FunctionContext, Program, ResolveResult};
 
 fn main() {
     let program = Program::compile("add(2, 3)").unwrap();
@@ -12,7 +12,7 @@ fn main() {
 /// The add function takes two arguments and returns their sum. We discard the first
 /// parameter because the add function is not a method, it is always called with two
 /// arguments.
-fn add(ftx: FunctionCtx) -> ResolveResult {
+fn add(ftx: FunctionContext) -> ResolveResult {
     let a = ftx.resolve_arg(0)?;
     let b = ftx.resolve_arg(1)?;
     Ok(a + b)

--- a/interpreter/benches/runtime.rs
+++ b/interpreter/benches/runtime.rs
@@ -1,5 +1,4 @@
 use cel_interpreter::context::Context;
-use cel_interpreter::objects::CelType;
 use cel_interpreter::Program;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::collections::HashMap;

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -391,7 +391,7 @@ pub fn timestamp(ftx: FunctionContext) -> Result<Value> {
     match value {
         Value::String(v) => Value::Timestamp(
             DateTime::parse_from_rfc3339(v.as_str())
-                .map_err(|e| ftx.error(e.to_string().as_str()))?,
+                .map_err(|e| ftx.error(e.to_string().as_str()).err().unwrap())?,
         ),
         _ => return Err(ExecutionError::unsupported_target_type(value)),
     }


### PR DESCRIPTION
Rationale:
* ctx is more of a go thing so I renamed the type to `FunctionContext`.
* We do a lot with `CelType` but it's really a value wrapper. Since it's already in the cel crate, the prefix seemed redundant.