### PR TITLE
Magic function parameters

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 cel-interpreter = { path = "../interpreter" }
+chrono = "0.4.26"
 
 [[bin]]
 name = "simple"

--- a/example/src/functions.rs
+++ b/example/src/functions.rs
@@ -1,4 +1,4 @@
-use cel_interpreter::{Context, FunctionContext, Program, ResolveResult};
+use cel_interpreter::{Argument, Context, FunctionContext, Program, ResolveResult};
 
 fn main() {
     let program = Program::compile("add(2, 3)").unwrap();
@@ -13,7 +13,7 @@ fn main() {
 /// parameter because the add function is not a method, it is always called with two
 /// arguments.
 fn add(ftx: FunctionContext) -> ResolveResult {
-    let a = ftx.resolve_arg(0)?;
-    let b = ftx.resolve_arg(1)?;
+    let a = ftx.resolve(Argument(0))?;
+    let b = ftx.resolve(Argument(1))?;
     Ok(a + b)
 }

--- a/example/src/functions.rs
+++ b/example/src/functions.rs
@@ -1,15 +1,43 @@
-use cel_interpreter::{Context, Program};
+use cel_interpreter::extractors::This;
+use cel_interpreter::{Context, ExecutionError, FunctionContext, Program, ResolveResult};
+use std::rc::Rc;
 
 fn main() {
-    let program = Program::compile("add(2, 3)").unwrap();
+    let program = Program::compile("add(2, 3) == 5 && ''.isEmpty() && fail()").unwrap();
     let mut context = Context::default();
-    context.add_function("add", add);
 
-    let value = program.execute(&context).unwrap();
-    assert_eq!(value, 5.into());
+    // Add functions using closures
+    context.add_function("add", |a: i32, b: i32| a + b);
+
+    // Add methods to a string type
+    context.add_function("isEmpty", is_empty);
+
+    // Use the function context to return error messages
+    context.add_function("fail", fail);
+
+    // Run the program
+    let result = program.execute(&context);
+    assert!(matches!(result, Err(ExecutionError::FunctionError { .. })));
 }
 
-/// The add function takes two arguments and returns their sum.
-fn add(a: i32, b: i32) -> i32 {
-    a + b
+/// A method on a string type. When added to the CEL context, this function
+/// can be called by running. We use the [`This`] extractor give us a reference
+/// to the string that this method was called on.
+///
+/// ```skip
+/// "foo".isEmpty()
+/// ```
+fn is_empty(This(s): This<Rc<String>>) -> bool {
+    s.is_empty()
+}
+
+/// A function that gives us access to the [`FunctionContext`]. All functions have
+/// can accept this context as their first argument. The context is helpful for
+/// several reasons:
+/// 1. Creating shadowed variables using cloned contexts (see the `filter` and `map`
+///    functions for example).
+/// 2. Functions that are fallible can return an error message using ftx.error(...)
+///    which attaches some helpful context for the error.
+fn fail(ftx: &FunctionContext) -> ResolveResult {
+    ftx.error("This function always fails").into()
 }

--- a/example/src/functions.rs
+++ b/example/src/functions.rs
@@ -9,11 +9,7 @@ fn main() {
     assert_eq!(value, 5.into());
 }
 
-/// The add function takes two arguments and returns their sum. We discard the first
-/// parameter because the add function is not a method, it is always called with two
-/// arguments.
-fn add(ftx: FunctionContext) -> ResolveResult {
-    let a = ftx.resolve(Argument(0))?;
-    let b = ftx.resolve(Argument(1))?;
-    Ok(a + b)
+/// The add function takes two arguments and returns their sum.
+fn add(a: i32, b: i32) -> i32 {
+    a + b
 }

--- a/example/src/functions.rs
+++ b/example/src/functions.rs
@@ -1,5 +1,7 @@
+#![allow(clippy::too_many_arguments)]
 use cel_interpreter::extractors::This;
-use cel_interpreter::{Context, ExecutionError, FunctionContext, Program, ResolveResult};
+use cel_interpreter::{Context, ExecutionError, FunctionContext, Program, ResolveResult, Value};
+use chrono::{DateTime, Duration, FixedOffset};
 use std::rc::Rc;
 
 fn main() {
@@ -14,6 +16,9 @@ fn main() {
 
     // Use the function context to return error messages
     context.add_function("fail", fail);
+
+    // See all the different value types you can accept in your functions
+    context.add_function("primitives", primitives);
 
     // Run the program
     let result = program.execute(&context);
@@ -40,4 +45,21 @@ fn is_empty(This(s): This<Rc<String>>) -> bool {
 ///    which attaches some helpful context for the error.
 fn fail(ftx: &FunctionContext) -> ResolveResult {
     ftx.error("This function always fails").into()
+}
+
+/// A function that illustrates all the different types of values that are supported
+/// as arguments to a function, as well as the fact that any of these types can also
+/// be returned from a function.
+fn primitives(
+    _a: i32,
+    _b: u32,
+    _c: f64,
+    _d: bool,
+    _e: Rc<String>,
+    _f: Rc<Vec<u8>>,
+    _g: Duration,
+    _h: DateTime<FixedOffset>,
+    _i: Rc<Vec<Value>>,
+) -> Duration {
+    Duration::zero()
 }

--- a/example/src/functions.rs
+++ b/example/src/functions.rs
@@ -1,4 +1,4 @@
-use cel_interpreter::{Argument, Context, FunctionContext, Program, ResolveResult};
+use cel_interpreter::{Context, Program};
 
 fn main() {
     let program = Program::compile("add(2, 3)").unwrap();

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -13,6 +13,7 @@ cel-parser = { path = "../parser", version = "0.3.0" }
 thiserror = "1.0.40"
 chrono = "0.4.26"
 nom = "7.1.3"
+paste = "1.0.14"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -24,15 +24,23 @@ auth.claims.email_verified && resources.all(r, r.startsWith(auth.claims.email))
 
 ## Getting Started
 
-This project includes a CEL-parser and an interpreter which means that it can be used to evaluate CEL-expressions. The
+This project includes a parser and an interpreter which means that it can be used to evaluate CEL-expressions. The
 library aims to be very simple to use, while still being fast, safe, and customizable.
 
 ```rust
+use cel_interpreter::{Context, Program};
+
 fn main() {
-    let program = Program::compile("1 == 1").unwrap();
-    let context = Context::default();
+    // Compile a CEL program
+    let program = Program::compile("add(2, 3)").unwrap();
+
+    // Add any variables or functions that the program will need
+    let mut context = Context::default();
+    context.add_function("add", |a: i32, b: i32| a + b);
+
+    // Run the program
     let value = program.execute(&context).unwrap();
-    assert_eq!(value, true.into());
+    assert_eq!(value, 5.into());
 }
 ```
 

--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -1,14 +1,8 @@
-use crate::functions::FunctionContext;
 use crate::magic::{Function, FunctionRegistry, Handler};
 use crate::objects::Value;
-use crate::{functions, ExecutionError, ResolveResult};
+use crate::{functions, ExecutionError};
 use cel_parser::Expression;
 use std::collections::HashMap;
-
-/// A function that can be loaded into the [`ParentContext`] and then called from a Common Expression
-/// Language program. If the function is a method, the first parameter will be the target object.
-/// If the function accepts arguments, they will be provided as expressions.
-type ContextFunction = dyn Fn(FunctionContext) -> ResolveResult;
 
 /// Context is a collection of variables and functions that can be used
 /// by the interpreter to resolve expressions. The context can be either

--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -132,17 +132,17 @@ impl<'a> Default for Context<'a> {
             variables: Default::default(),
             functions: Default::default(),
         };
-        // ctx.add_function("contains", functions::contains);
-        // ctx.add_function("size", functions::size);
-        // ctx.add_function("has", functions::has);
-        // ctx.add_function("map", functions::map);
-        // ctx.add_function("filter", functions::filter);
-        // ctx.add_function("all", functions::all);
-        // ctx.add_function("max", functions::max);
+        ctx.add_function("contains", functions::contains);
+        ctx.add_function("size", functions::size);
+        ctx.add_function("has", functions::has);
+        ctx.add_function("map", functions::map);
+        ctx.add_function("filter", functions::filter);
+        ctx.add_function("all", functions::all);
+        ctx.add_function("max", functions::max);
         ctx.add_function("startsWith", functions::starts_with);
-        // ctx.add_function("duration", functions::duration);
-        // ctx.add_function("timestamp", functions::timestamp);
-        // ctx.add_function("string", functions::string);
+        ctx.add_function("duration", functions::duration);
+        ctx.add_function("timestamp", functions::timestamp);
+        ctx.add_function("string", functions::string);
         ctx.add_function("double", functions::double);
         ctx
     }

--- a/interpreter/src/duration.rs
+++ b/interpreter/src/duration.rs
@@ -121,7 +121,7 @@ pub fn format_duration(d: &Duration) -> String {
     if u < SECOND {
         // Special case: if duration is smaller than a second,
         // use smaller units, like 1.2ms
-        let mut prec = 0;
+        let mut _prec = 0;
         w -= 1;
         buf[w] = b's';
         w -= 1;
@@ -129,19 +129,19 @@ pub fn format_duration(d: &Duration) -> String {
         if u == 0 {
             return "0s".to_string();
         } else if u < MICROSECOND {
-            prec = 0;
+            _prec = 0;
             buf[w] = b'n';
         } else if u < MILLISECOND {
-            prec = 3;
+            _prec = 3;
             // U+00B5 'µ' micro sign == 0xC2 0xB5
             buf[w] = 0xB5;
             w -= 1;
             buf[w] = 0xC2;
         } else {
-            prec = 6;
+            _prec = 6;
             buf[w] = b'm';
         }
-        (w, u) = format_float(&mut buf[..w], u, prec);
+        (w, u) = format_float(&mut buf[..w], u, _prec);
         w = format_int(&mut buf[..w], u);
     } else {
         w -= 1;

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -437,18 +437,6 @@ impl FromTarget for Rc<String> {
     }
 }
 
-pub trait FromExpression {
-    fn from_expression(expr: &Expression) -> Result<&Self>
-    where
-        Self: Sized;
-}
-
-impl FromExpression for Expression {
-    fn from_expression(expr: &Expression) -> Result<&Self> {
-        Ok(expr)
-    }
-}
-
 /// A wrapper around [`parse_duration`] that converts errors into [`ExecutionError`].
 /// and only returns the duration, rather than returning the remaining input.
 fn _duration(i: &str) -> Result<Duration> {

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -40,20 +40,6 @@ impl<'context> FunctionContext<'context> {
         }
     }
 
-    /// Returns a reference to the target object if the function is being called
-    /// as a method, or it returns an error if the function is not being called
-    /// as a method.
-    pub fn this<T>(&self) -> Result<&T>
-    where
-        T: FromThis,
-    {
-        let target = self
-            .this
-            .as_ref()
-            .ok_or(ExecutionError::missing_argument_or_target())?;
-        T::from_this(target)
-    }
-
     /// Resolves the given expression using the program's [`Context`].
     pub fn resolve<R>(&self, resolver: R) -> Result<Value>
     where
@@ -360,27 +346,6 @@ pub fn max(Arguments(args): Arguments) -> Result<Value> {
         });
     }
     args.iter().max().cloned().unwrap_or(Value::Null).into()
-}
-
-pub trait FromThis {
-    fn from_this(target: &Value) -> Result<&Self>
-    where
-        Self: Sized;
-}
-
-impl FromThis for Value {
-    fn from_this(target: &Value) -> Result<&Self> {
-        Ok(target)
-    }
-}
-
-impl FromThis for Rc<String> {
-    fn from_this(target: &Value) -> Result<&Self> {
-        match target {
-            Value::String(v) => Ok(v),
-            _ => Err(ExecutionError::unsupported_target_type(target.clone())),
-        }
-    }
 }
 
 /// A wrapper around [`parse_duration`] that converts errors into [`ExecutionError`].

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -1,6 +1,6 @@
 use crate::context::Context;
 use crate::duration::{format_duration, parse_duration};
-use crate::magic::{Arguments, Identifier, IntoResolveResult, This};
+use crate::magic::{Arguments, Identifier, This};
 use crate::objects::{Value, ValueType};
 use crate::{Argument, ExecutionError, Resolver};
 use cel_parser::Expression;
@@ -303,7 +303,7 @@ pub fn all(
         Value::List(items) => {
             let mut ptx = ftx.ptx.clone();
             for item in items.iter() {
-                ptx.add_variable(ident.clone(), item.clone());
+                ptx.add_variable(&ident, item);
                 if let Value::Bool(false) = ptx.resolve(&expr)? {
                     return Ok(false);
                 }
@@ -313,7 +313,7 @@ pub fn all(
         Value::Map(value) => {
             let mut ptx = ftx.ptx.clone();
             for key in value.map.keys() {
-                ptx.add_variable(ident.clone(), key.clone());
+                ptx.add_variable(&ident, key);
                 if let Value::Bool(false) = ptx.resolve(&expr)? {
                     return Ok(false);
                 }

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -1,6 +1,6 @@
 use crate::context::Context;
 use crate::duration::{format_duration, parse_duration};
-use crate::magic::Target;
+use crate::magic::This;
 use crate::objects::Value;
 use crate::{Argument, Arguments, ExecutionError, Resolver};
 use cel_parser::Expression;
@@ -223,8 +223,8 @@ pub fn double(value: Value) -> Result<Value> {
 /// ```cel
 /// "abc".startsWith("a") == true
 /// ```
-pub fn starts_with(Target(target): Target<Rc<String>>, prefix: Rc<String>) -> bool {
-    target.starts_with(prefix.as_str())
+pub fn starts_with(This(this): This<Rc<String>>, prefix: Rc<String>) -> bool {
+    this.starts_with(prefix.as_str())
 }
 
 /// Returns true if the provided argument can be resolved. This function is

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -2,7 +2,8 @@ use crate::context::Context;
 use crate::duration::{format_duration, parse_duration};
 use crate::magic::{Arguments, Identifier, This};
 use crate::objects::{Value, ValueType};
-use crate::{Argument, ExecutionError, Resolver};
+use crate::resolvers::{Argument, Resolver};
+use crate::ExecutionError;
 use cel_parser::Expression;
 use chrono::{DateTime, Duration, FixedOffset};
 use std::convert::TryInto;
@@ -393,10 +394,6 @@ fn _duration(i: &str) -> Result<Duration> {
 fn _timestamp(i: &str) -> Result<DateTime<FixedOffset>> {
     DateTime::parse_from_rfc3339(i)
         .map_err(|e| ExecutionError::function_error("timestamp", &e.to_string()))
-}
-
-fn is_numeric(target: &&Value) -> bool {
-    matches!(target, Value::Int(_) | Value::UInt(_) | Value::Float(_))
 }
 
 #[cfg(test)]

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -13,7 +13,9 @@ pub use objects::{ResolveResult, Value};
 mod duration;
 mod functions;
 pub mod objects;
+mod resolvers;
 mod testing;
+pub use resolvers::{Argument, Arguments, Resolver};
 
 #[derive(Error, Debug)]
 #[error("Error parsing {msg}")]

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -12,9 +12,11 @@ pub use functions::FunctionContext;
 pub use objects::{ResolveResult, Value};
 mod duration;
 mod functions;
+mod magic;
 pub mod objects;
 mod resolvers;
 mod testing;
+
 pub use resolvers::{Argument, Arguments, Resolver};
 
 #[derive(Error, Debug)]
@@ -35,6 +37,8 @@ pub enum ExecutionError {
     /// but the type of the value was not supported as a key.
     #[error("Unable to use value '{0:?}' as a key")]
     UnsupportedKeyType(Value),
+    #[error("Unexpected type: got '{got}', want '{want}'")]
+    UnexpectedType { got: String, want: String },
     /// Indicates that the script attempted to reference a key on a type that
     /// was missing the requested key.
     #[error("No such key: {0}")]

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -21,7 +21,6 @@ mod testing;
 use magic::FromContext;
 
 pub use magic::{Arguments, Identifier, This};
-pub use resolvers::{AllArguments, Argument, Resolver};
 
 #[derive(Error, Debug)]
 #[error("Error parsing {msg}")]

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -20,7 +20,9 @@ mod resolvers;
 mod testing;
 use magic::FromContext;
 
-pub use magic::{Arguments, Identifier, This};
+pub mod extractors {
+    pub use crate::magic::{Arguments, Identifier, This};
+}
 
 #[derive(Error, Debug)]
 #[error("Error parsing {msg}")]

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -17,7 +17,7 @@ pub mod objects;
 mod resolvers;
 mod testing;
 
-pub use resolvers::{Argument, Arguments, Resolver};
+pub use resolvers::{AllArguments, Argument, Resolver};
 
 #[derive(Error, Debug)]
 #[error("Error parsing {msg}")]

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -5,6 +5,8 @@ use std::convert::TryFrom;
 use std::rc::Rc;
 use thiserror::Error;
 
+mod macros;
+
 pub mod context;
 pub use cel_parser::Expression;
 pub use context::Context;
@@ -16,7 +18,9 @@ mod magic;
 pub mod objects;
 mod resolvers;
 mod testing;
+use magic::FromContext;
 
+pub use magic::{Arguments, Identifier, This};
 pub use resolvers::{AllArguments, Argument, Resolver};
 
 #[derive(Error, Debug)]

--- a/interpreter/src/macros.rs
+++ b/interpreter/src/macros.rs
@@ -71,9 +71,9 @@ macro_rules! impl_handler {
             {
                 fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
                     $(
-                        let [<arg_ $t>] = $t::from_context(ftx)?;
+                        let [<arg_ $t:lower>] = $t::from_context(ftx)?;
                     )*
-                    self($([<arg_ $t>],)*).into_resolve_result()
+                    self($([<arg_ $t:lower>],)*).into_resolve_result()
                 }
             }
 
@@ -85,9 +85,9 @@ macro_rules! impl_handler {
             {
                 fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
                     $(
-                        let [<arg_ $t>] = $t::from_context(ftx)?;
+                        let [<arg_ $t:lower>] = $t::from_context(ftx)?;
                     )*
-                    self(ftx, $([<arg_ $t>],)*).into_resolve_result()
+                    self(ftx, $([<arg_ $t:lower>],)*).into_resolve_result()
                 }
             }
         }

--- a/interpreter/src/macros.rs
+++ b/interpreter/src/macros.rs
@@ -1,0 +1,103 @@
+#[macro_export]
+macro_rules! impl_from_value {
+    ($target_type:ty, $value_variant:path) => {
+        impl FromValue for $target_type {
+            fn from_value(expr: &Value) -> Result<Self, ExecutionError> {
+                if let $value_variant(v) = expr {
+                    Ok(v.clone())
+                } else {
+                    Err(ExecutionError::UnexpectedType {
+                        got: format!("{:?}", expr),
+                        want: stringify!($target_type).to_string(),
+                    })
+                }
+            }
+        }
+
+        impl FromValue for Option<$target_type> {
+            fn from_value(expr: &Value) -> Result<Self, ExecutionError> {
+                match expr {
+                    Value::Null => Ok(None),
+                    $value_variant(v) => Ok(Some(v.clone())),
+                    _ => Err(ExecutionError::UnexpectedType {
+                        got: format!("{:?}", expr),
+                        want: stringify!($target_type).to_string(),
+                    }),
+                }
+            }
+        }
+
+        impl From<$target_type> for Value {
+            fn from(value: $target_type) -> Self {
+                $value_variant(value)
+            }
+        }
+
+        impl crate::magic::IntoResolveResult for $target_type {
+            fn into_resolve_result(self) -> ResolveResult {
+                Ok($value_variant(self))
+            }
+        }
+
+        impl crate::magic::IntoResolveResult for Result<$target_type, ExecutionError> {
+            fn into_resolve_result(self) -> ResolveResult {
+                self.map($value_variant)
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_arg_value_from_context {
+    ($($type:ty),*) => {
+        $(
+            impl<'a, 'context> FromContext<'a, 'context> for $type {
+                fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+                where
+                    Self: Sized,
+                {
+                    arg_value_from_context(ctx).and_then(|v| FromValue::from_value(&v))
+                }
+            }
+        )*
+    };
+}
+
+#[macro_export]
+macro_rules! impl_handler {
+    ($($t:ty),*) => {
+        paste::paste! {
+            impl<F, $($t,)* R> Handler<($($t,)*)> for F
+            where
+                F: Fn($($t,)*) -> R + Clone,
+                $($t: for<'a, 'context> crate::FromContext<'a, 'context>,)*
+                R: IntoResolveResult,
+            {
+                fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+                    $(
+                        let [<arg_ $t>] = $t::from_context(ftx)?;
+                    )*
+                    self($([<arg_ $t>],)*).into_resolve_result()
+                }
+            }
+
+            impl<F, $($t,)* R> Handler<(WithFunctionContext, $($t,)*)> for F
+            where
+                F: Fn(&FunctionContext, $($t,)*) -> R + Clone,
+                $($t: for<'a, 'context> crate::FromContext<'a, 'context>,)*
+                R: IntoResolveResult,
+            {
+                fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+                    $(
+                        let [<arg_ $t>] = $t::from_context(ftx)?;
+                    )*
+                    self(ftx, $([<arg_ $t>],)*).into_resolve_result()
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use impl_arg_value_from_context;
+pub(crate) use impl_from_value;
+pub(crate) use impl_handler;

--- a/interpreter/src/macros.rs
+++ b/interpreter/src/macros.rs
@@ -69,9 +69,9 @@ macro_rules! impl_handler {
                 $($t: for<'a, 'context> crate::FromContext<'a, 'context>,)*
                 R: IntoResolveResult,
             {
-                fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+                fn call(self, _ftx: &mut FunctionContext) -> ResolveResult {
                     $(
-                        let [<arg_ $t:lower>] = $t::from_context(ftx)?;
+                        let [<arg_ $t:lower>] = $t::from_context(_ftx)?;
                     )*
                     self($([<arg_ $t:lower>],)*).into_resolve_result()
                 }
@@ -83,11 +83,11 @@ macro_rules! impl_handler {
                 $($t: for<'a, 'context> crate::FromContext<'a, 'context>,)*
                 R: IntoResolveResult,
             {
-                fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+                fn call(self, _ftx: &mut FunctionContext) -> ResolveResult {
                     $(
-                        let [<arg_ $t:lower>] = $t::from_context(ftx)?;
+                        let [<arg_ $t:lower>] = $t::from_context(_ftx)?;
                     )*
-                    self(ftx, $([<arg_ $t:lower>],)*).into_resolve_result()
+                    self(_ftx, $([<arg_ $t:lower>],)*).into_resolve_result()
                 }
             }
         }

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -1,0 +1,170 @@
+use crate::{Argument, ExecutionError, FunctionContext, ResolveResult, Value};
+use cel_parser::{Atom, Expression};
+use chrono::{DateTime, Duration, FixedOffset};
+use std::rc::Rc;
+
+macro_rules! impl_from_value {
+    ($target_type:ty, $value_variant:path) => {
+        impl FromValue for $target_type {
+            fn from(expr: &Value) -> Result<Self, ExecutionError> {
+                if let $value_variant(v) = expr {
+                    Ok(v.clone())
+                } else {
+                    Err(ExecutionError::UnexpectedType {
+                        got: format!("{:?}", expr),
+                        want: stringify!($target_type).to_string(),
+                    })
+                }
+            }
+        }
+
+        impl FromValue for Option<$target_type> {
+            fn from(expr: &Value) -> Result<Self, ExecutionError> {
+                match expr {
+                    Value::Null => Ok(None),
+                    $value_variant(v) => Ok(Some(v.clone())),
+                    _ => Err(ExecutionError::UnexpectedType {
+                        got: format!("{:?}", expr),
+                        want: stringify!($target_type).to_string(),
+                    }),
+                }
+            }
+        }
+
+        impl From<$target_type> for Value {
+            fn from(value: $target_type) -> Self {
+                $value_variant(value)
+            }
+        }
+
+        impl IntoResolveResult for $target_type {
+            fn into_resolve_result(self) -> ResolveResult {
+                Ok($value_variant(self))
+            }
+        }
+    };
+}
+
+// impl<F, T1, T2> Callable<(T1, T2)> for F
+// where
+//     F: Fn(T1, T2),
+//     T1: FromValue,
+//     T2: FromValue,
+// {
+//     fn call(&self, ftx: FunctionContext) -> ResolveResult {
+//         let arg1 = ftx.resolve(Argument(0))?;
+//         let arg2 = ftx.resolve(Argument(1))?;
+//         let t1 = T1::from(&arg1)?;
+//         let t2 = T2::from(&arg2)?;
+//         self(t1, t2);
+//         Ok(Value::Null)
+//     }
+// }
+
+// macro_rules! impl_callable {
+//     ($($ty: ident),+) => {
+//         impl<F, $($ty,)* R> Callable<($($ty,)*)> for F
+//         where
+//             F: Fn($($ty,)*) -> R + 'static,
+//             $( $ty: FromValue, )*
+//             R: IntoResolveResult,
+//         {
+//             fn call(&self, ftx: FunctionContext) -> ResolveResult {
+//                 $(let $ty = $ty::from(&ftx.resolve(Argument(0))?)?;)*
+//                 self($($ty),*).into_resolve_result()
+//             }
+//         }
+//     }
+// }
+
+macro_rules! impl_callable {
+    // Base case: no more types.
+    (@go $idx: expr, [], $call: expr, $ftx: ident, [$($args:tt)*]) => {
+        $call($($args)*).into_resolve_result()
+    };
+
+    // Recurse for each ident, incrementing the index each time.
+    (@go $idx: expr, [$head: ident, $($tail: ident,)*], $call: expr, $ftx: ident, [$($args:tt)*]) => {
+        impl_callable!(@go $idx + 1, [$($tail,)*], $call, $ftx, [
+            $($args)*
+            {
+                let temp = $head::from(&$ftx.resolve(Argument($idx))?)?;
+                temp
+            },
+        ])
+    };
+
+    // Main entry point.
+    ($($ty: ident),+ $(,)?) => {
+        impl<F, $($ty,)* R> Callable<($($ty,)*)> for F
+        where
+            F: Fn($($ty,)*) -> R + 'static,
+            $( $ty: FromValue, )*
+            R: IntoResolveResult,
+        {
+            fn call(&self, ftx: FunctionContext) -> ResolveResult {
+                impl_callable!(@go 0, [$($ty,)*], self, ftx, [])
+            }
+        }
+    }
+}
+
+pub(crate) trait Callable<T> {
+    fn call(&self, ftx: FunctionContext) -> ResolveResult;
+}
+
+trait FromValue {
+    fn from(expr: &Value) -> Result<Self, ExecutionError>
+    where
+        Self: Sized;
+}
+
+trait IntoResolveResult {
+    fn into_resolve_result(self) -> ResolveResult;
+}
+
+impl IntoResolveResult for String {
+    fn into_resolve_result(self) -> ResolveResult {
+        Ok(Value::String(Rc::new(self)))
+    }
+}
+
+impl_from_value!(i32, Value::Int);
+impl_from_value!(u32, Value::UInt);
+impl_from_value!(f64, Value::Float);
+impl_from_value!(Rc<String>, Value::String);
+impl_from_value!(Rc<Vec<u8>>, Value::Bytes);
+impl_from_value!(bool, Value::Bool);
+impl_from_value!(Duration, Value::Duration);
+impl_from_value!(DateTime<FixedOffset>, Value::Timestamp);
+
+impl_callable!(T1);
+impl_callable!(T1, T2);
+
+fn call_function<T, H>(function: H) -> ResolveResult
+where
+    H: Callable<T>,
+{
+    function.call(FunctionContext {
+        name: Rc::new("".to_string()),
+        target: None,
+        ptx: &Default::default(),
+        args: &[
+            Expression::Atom(Atom::UInt(10)),
+            Expression::Atom(Atom::UInt(20)),
+            // Expression::Atom(Atom::Null),
+            // Expression::Atom(Atom::String(Rc::new("world".to_string()))),
+        ],
+    })
+}
+
+fn add(a: u32, b: u32) -> u32 {
+    a + b
+}
+
+#[test]
+fn test_foo() {
+    let result = call_function(add);
+    // let result = call_function(greet);
+    println!("{:?}", result);
+}

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -1,5 +1,6 @@
 use crate::macros::{impl_conversions, impl_handler};
-use crate::{AllArguments, Argument, ExecutionError, FunctionContext, ResolveResult, Value};
+use crate::resolvers::{AllArguments, Argument};
+use crate::{ExecutionError, FunctionContext, ResolveResult, Value};
 use cel_parser::Expression;
 use chrono::{DateTime, Duration, FixedOffset};
 use std::collections::HashMap;
@@ -322,20 +323,12 @@ impl FunctionRegistry {
     pub(crate) fn has(&self, name: &str) -> bool {
         self.functions.contains_key(name)
     }
-
-    fn call(&self, name: &str, ctx: &mut FunctionContext) -> ResolveResult {
-        self.functions
-            .get(name)
-            .unwrap()
-            .clone_box()
-            .call_with_context(ctx)
-    }
 }
 
 pub trait Function {
     fn clone_box(&self) -> Box<dyn Function>;
     fn into_callable<'a>(self: Box<Self>, ctx: &'a mut FunctionContext) -> Box<dyn Callable + 'a>;
-    fn call_with_context<'a>(self: Box<Self>, ctx: &'a mut FunctionContext) -> ResolveResult;
+    fn call_with_context(self: Box<Self>, ctx: &mut FunctionContext) -> ResolveResult;
 }
 
 pub struct HandlerFunction<H: Clone> {
@@ -364,7 +357,7 @@ where
         (self.into_callable)(self.handler, ctx)
     }
 
-    fn call_with_context<'a>(self: Box<Self>, ctx: &'a mut FunctionContext) -> ResolveResult {
+    fn call_with_context(self: Box<Self>, ctx: &mut FunctionContext) -> ResolveResult {
         self.into_callable(ctx).call()
     }
 }

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -1,6 +1,9 @@
+use crate::functions::FromTarget;
 use crate::{Argument, ExecutionError, FunctionContext, ResolveResult, Value};
 use cel_parser::{Atom, Expression};
 use chrono::{DateTime, Duration, FixedOffset};
+use std::collections::HashMap;
+use std::marker::PhantomData;
 use std::rc::Rc;
 
 macro_rules! impl_from_value {
@@ -45,47 +48,34 @@ macro_rules! impl_from_value {
     };
 }
 
-// impl<F, T1, T2> Callable<(T1, T2)> for F
-// where
-//     F: Fn(T1, T2),
-//     T1: FromValue,
-//     T2: FromValue,
-// {
-//     fn call(&self, ftx: FunctionContext) -> ResolveResult {
-//         let arg1 = ftx.resolve(Argument(0))?;
-//         let arg2 = ftx.resolve(Argument(1))?;
-//         let t1 = T1::from(&arg1)?;
-//         let t2 = T2::from(&arg2)?;
-//         self(t1, t2);
-//         Ok(Value::Null)
-//     }
-// }
+pub struct WithTarget;
+pub struct NoTarget;
 
-// macro_rules! impl_callable {
-//     ($($ty: ident),+) => {
-//         impl<F, $($ty,)* R> Callable<($($ty,)*)> for F
-//         where
-//             F: Fn($($ty,)*) -> R + 'static,
-//             $( $ty: FromValue, )*
-//             R: IntoResolveResult,
-//         {
-//             fn call(&self, ftx: FunctionContext) -> ResolveResult {
-//                 $(let $ty = $ty::from(&ftx.resolve(Argument(0))?)?;)*
-//                 self($($ty),*).into_resolve_result()
-//             }
-//         }
-//     }
-// }
+macro_rules! impl_handler {
+    // Base case: no more types, with a target
+    (@go_with_target $idx: expr, $call: expr, $ftx: ident, $target: ident, [], [$($args:tt)*]) => {
+        $call($target, $($args)*).into_resolve_result()
+    };
 
-macro_rules! impl_callable {
-    // Base case: no more types.
-    (@go $idx: expr, [], $call: expr, $ftx: ident, [$($args:tt)*]) => {
+    // Base case: no more types, without a target
+    (@go_without_target $idx: expr, $call: expr, $ftx: ident, [], [$($args:tt)*]) => {
         $call($($args)*).into_resolve_result()
     };
 
-    // Recurse for each ident, incrementing the index each time.
-    (@go $idx: expr, [$head: ident, $($tail: ident,)*], $call: expr, $ftx: ident, [$($args:tt)*]) => {
-        impl_callable!(@go $idx + 1, [$($tail,)*], $call, $ftx, [
+    // Recurse for each ident, incrementing the index each time, with a target
+    (@go_with_target $idx: expr, $call: expr, $ftx: ident, $target: ident, [$head: ident, $($tail: ident,)*], [$($args:tt)*]) => {
+        impl_handler!(@go_with_target $idx + 1, $call, $ftx, $target, [$($tail,)*], [
+            $($args)*
+            {
+                let temp = $head::from(&$ftx.resolve(Argument($idx))?)?;
+                temp
+            },
+        ])
+    };
+
+    // Recurse for each ident, incrementing the index each time, without a target
+    (@go_without_target $idx: expr, $call: expr, $ftx: ident, [$head: ident, $($tail: ident,)*], [$($args:tt)*]) => {
+        impl_handler!(@go_without_target $idx + 1, $call, $ftx, [$($tail,)*], [
             $($args)*
             {
                 let temp = $head::from(&$ftx.resolve(Argument($idx))?)?;
@@ -96,27 +86,66 @@ macro_rules! impl_callable {
 
     // Main entry point.
     ($($ty: ident),+ $(,)?) => {
-        impl<F, $($ty,)* R> Callable<($($ty,)*)> for F
+        impl<F, Target, $($ty,)* R> Handler<(WithTarget, Target, $($ty,)*)> for F
         where
-            F: Fn($($ty,)*) -> R + 'static,
+            F: Fn(Target, $($ty,)*) -> R + Clone + 'static,
+            Target: FromContext,
             $( $ty: FromValue, )*
             R: IntoResolveResult,
         {
-            fn call(&self, ftx: FunctionContext) -> ResolveResult {
-                impl_callable!(@go 0, [$($ty,)*], self, ftx, [])
+            fn call(self, ftx: FunctionContext) -> ResolveResult {
+                let target = Target::from_context(&ftx)?;
+                impl_handler!(@go_with_target 0, self, ftx, target, [$($ty,)*], [])
+            }
+        }
+
+        impl<F, $($ty,)* R> Handler<(NoTarget, $($ty,)*)> for F
+        where
+            F: Fn($($ty,)*) -> R + Clone + 'static,
+            $( $ty: FromValue, )*
+            R: IntoResolveResult,
+        {
+            fn call(self, ftx: FunctionContext) -> ResolveResult {
+                impl_handler!(@go_without_target 0, self, ftx, [$($ty,)*], [])
             }
         }
     }
-}
-
-pub(crate) trait Callable<T> {
-    fn call(&self, ftx: FunctionContext) -> ResolveResult;
 }
 
 trait FromValue {
     fn from(expr: &Value) -> Result<Self, ExecutionError>
     where
         Self: Sized;
+}
+
+impl FromValue for Value {
+    fn from(expr: &Value) -> Result<Self, ExecutionError>
+    where
+        Self: Sized,
+    {
+        Ok(expr.clone())
+    }
+}
+
+trait FromContext {
+    fn from_context(ctx: &FunctionContext) -> Result<Self, ExecutionError>
+    where
+        Self: Sized;
+}
+
+pub struct Target<T>(pub T);
+
+impl<T> FromContext for Target<T>
+where
+    T: FromValue,
+{
+    fn from_context(ctx: &FunctionContext) -> Result<Self, ExecutionError>
+    where
+        Self: Sized,
+    {
+        let value = ctx.target::<Value>()?;
+        Ok(Target(T::from(value)?))
+    }
 }
 
 trait IntoResolveResult {
@@ -129,6 +158,12 @@ impl IntoResolveResult for String {
     }
 }
 
+impl IntoResolveResult for Result<Value, ExecutionError> {
+    fn into_resolve_result(self) -> ResolveResult {
+        self
+    }
+}
+
 impl_from_value!(i32, Value::Int);
 impl_from_value!(u32, Value::UInt);
 impl_from_value!(f64, Value::Float);
@@ -138,33 +173,215 @@ impl_from_value!(bool, Value::Bool);
 impl_from_value!(Duration, Value::Duration);
 impl_from_value!(DateTime<FixedOffset>, Value::Timestamp);
 
-impl_callable!(T1);
-impl_callable!(T1, T2);
+impl_handler!(T1);
+impl_handler!(T1, T2);
 
-fn call_function<T, H>(function: H) -> ResolveResult
-where
-    H: Callable<T>,
-{
-    function.call(FunctionContext {
-        name: Rc::new("".to_string()),
-        target: None,
-        ptx: &Default::default(),
-        args: &[
-            Expression::Atom(Atom::UInt(10)),
-            Expression::Atom(Atom::UInt(20)),
-            // Expression::Atom(Atom::Null),
-            // Expression::Atom(Atom::String(Rc::new("world".to_string()))),
-        ],
-    })
+// // Implementation with target
+// impl<F, Target, A1, R> Handler<(WithTarget, Target, A1)> for F
+// where
+//     F: Fn(Target, A1) -> R + Clone + 'static,
+//     Target: FromContext,
+//     A1: FromValue,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: FunctionContext) -> ResolveResult {
+//         let target = Target::from_context(&ftx)?;
+//         let arg = ftx.resolve(Argument(0))?;
+//         let arg = A1::from(&arg)?;
+//         self(target, arg).into_resolve_result()
+//     }
+// }
+//
+// // Implementation without target
+// impl<F, A1, R> Handler<(NoTarget, A1)> for F
+// where
+//     F: Fn(A1) -> R + Clone + 'static,
+//     A1: FromValue,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: FunctionContext) -> ResolveResult {
+//         let arg = ftx.resolve(Argument(0))?;
+//         let arg = A1::from(&arg)?;
+//         self(arg).into_resolve_result()
+//     }
+// }
+//
+// // Implementation with target
+// impl<F, Target, A1, A2, R> Handler<(WithTarget, Target, A1, A2)> for F
+// where
+//     F: Fn(Target, A1, A2) -> R + Clone + 'static,
+//     Target: FromContext,
+//     A1: FromValue,
+//     A2: FromValue,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: FunctionContext) -> ResolveResult {
+//         let target = Target::from_context(&ftx)?;
+//         let arg1 = ftx.resolve(Argument(0))?;
+//         let arg2 = ftx.resolve(Argument(1))?;
+//         let arg1 = A1::from(&arg1)?;
+//         let arg2 = A2::from(&arg2)?;
+//         self(target, arg1, arg2).into_resolve_result()
+//     }
+// }
+//
+// // Implementation without target
+// impl<F, A1, A2, R> Handler<(NoTarget, A1, A2)> for F
+// where
+//     F: Fn(A1, A2) -> R + Clone + 'static,
+//     A1: FromValue,
+//     A2: FromValue,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: FunctionContext) -> ResolveResult {
+//         let arg1 = ftx.resolve(Argument(0))?;
+//         let arg2 = ftx.resolve(Argument(1))?;
+//         let arg1 = A1::from(&arg1)?;
+//         let arg2 = A2::from(&arg2)?;
+//         self(arg1, arg2).into_resolve_result()
+//     }
+// }
+
+// Heavily inspired by https://users.rust-lang.org/t/common-data-type-for-functions-with-different-parameters-e-g-axum-route-handlers/90207/6
+// and https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c6744c27c2358ec1d1196033a0ec11e4
+
+#[derive(Default)]
+pub struct FunctionRegistry {
+    routes: HashMap<String, Box<dyn Function>>,
 }
 
-fn add(a: u32, b: u32) -> u32 {
+impl FunctionRegistry {
+    pub(crate) fn add<H, T>(&mut self, name: &str, handler: H)
+    where
+        H: Handler<T> + 'static,
+        T: 'static,
+    {
+        self.routes.insert(
+            name.to_string(),
+            Box::new(HandlerFunction {
+                handler,
+                into_callable: |h, ctx| Box::new(HandlerCallable::new(h, ctx)),
+            }),
+        );
+    }
+
+    pub(crate) fn get(&self, name: &str) -> Option<Box<dyn Function>> {
+        self.routes.get(name).map(|f| f.clone_box())
+    }
+
+    pub(crate) fn has(&self, name: &str) -> bool {
+        self.routes.contains_key(name)
+    }
+
+    fn call(&self, name: &str, ctx: &FunctionContext) -> ResolveResult {
+        self.routes
+            .get(name)
+            .unwrap()
+            .clone_box()
+            .call_with_context(ctx)
+    }
+}
+
+pub trait Function {
+    fn clone_box(&self) -> Box<dyn Function>;
+    fn into_callable<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> Box<dyn Callable + 'a>;
+    fn call_with_context<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> ResolveResult;
+}
+
+pub struct HandlerFunction<H: Clone> {
+    pub handler: H,
+    pub into_callable: for<'a> fn(H, &'a FunctionContext) -> Box<dyn Callable + 'a>,
+}
+
+impl<H: Clone> Clone for HandlerFunction<H> {
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            into_callable: self.into_callable,
+        }
+    }
+}
+
+impl<H> Function for HandlerFunction<H>
+where
+    H: Clone + 'static,
+{
+    fn clone_box(&self) -> Box<dyn Function> {
+        Box::new(self.clone())
+    }
+
+    fn into_callable<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> Box<dyn Callable + 'a> {
+        (self.into_callable)(self.handler, ctx)
+    }
+
+    fn call_with_context<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> ResolveResult {
+        self.into_callable(ctx).call()
+    }
+}
+
+// Callable and HandlerCallable
+pub trait Callable {
+    fn call(&mut self) -> ResolveResult;
+}
+
+pub struct HandlerCallable<'a, H, T> {
+    handler: H,
+    context: &'a FunctionContext<'a, 'a, 'a>,
+    _marker: PhantomData<fn() -> T>,
+}
+
+impl<'a, H, T> HandlerCallable<'a, H, T> {
+    pub fn new(handler: H, ctx: &'a FunctionContext) -> Self {
+        Self {
+            handler,
+            context: ctx,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, H, T> Callable for HandlerCallable<'a, H, T>
+where
+    H: Handler<T> + Clone + 'static,
+{
+    fn call(&mut self) -> ResolveResult {
+        self.handler.clone().call(self.context.clone())
+    }
+}
+
+pub trait Handler<T>: Clone {
+    fn call(self, ctx: FunctionContext) -> ResolveResult;
+}
+
+fn double(x: i32) -> i32 {
+    x * 2
+}
+
+fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 
+fn starts_with(Target(target): Target<Rc<String>>, name: Rc<String>) -> bool {
+    target.starts_with(name.as_str())
+}
+
 #[test]
-fn test_foo() {
-    let result = call_function(add);
-    // let result = call_function(greet);
-    println!("{:?}", result);
+fn test() {
+    let mut router = FunctionRegistry::default();
+    // router.add("double", double);
+    // router.add("add", add);
+    router.add("starts_with", starts_with);
+    let target = Value::String(Rc::new("foobar".to_string()));
+    let ctx = FunctionContext {
+        name: Rc::new("".to_string()),
+        target: Some(&target),
+        ptx: &Default::default(),
+        args: &[
+            Expression::Atom(Atom::String(Rc::new("foo".to_string()))),
+            // Expression::Atom(Atom::Int(20)),
+        ],
+    };
+
+    let result = router.call("starts_with", &ctx);
+    println!("{:?}", result)
 }

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -1,5 +1,7 @@
-use crate::functions::FromTarget;
-use crate::{Argument, ExecutionError, FunctionContext, ResolveResult, Value};
+use crate::functions::FromThis;
+use crate::{
+    AllArguments, Argument, Context, ExecutionError, FunctionContext, ResolveResult, Value,
+};
 use cel_parser::{Atom, Expression};
 use chrono::{DateTime, Duration, FixedOffset};
 use std::collections::HashMap;
@@ -9,7 +11,7 @@ use std::rc::Rc;
 macro_rules! impl_from_value {
     ($target_type:ty, $value_variant:path) => {
         impl FromValue for $target_type {
-            fn from(expr: &Value) -> Result<Self, ExecutionError> {
+            fn from_value(expr: &Value) -> Result<Self, ExecutionError> {
                 if let $value_variant(v) = expr {
                     Ok(v.clone())
                 } else {
@@ -22,7 +24,7 @@ macro_rules! impl_from_value {
         }
 
         impl FromValue for Option<$target_type> {
-            fn from(expr: &Value) -> Result<Self, ExecutionError> {
+            fn from_value(expr: &Value) -> Result<Self, ExecutionError> {
                 match expr {
                     Value::Null => Ok(None),
                     $value_variant(v) => Ok(Some(v.clone())),
@@ -45,110 +47,195 @@ macro_rules! impl_from_value {
                 Ok($value_variant(self))
             }
         }
+
+        impl IntoResolveResult for Result<$target_type, ExecutionError> {
+            fn into_resolve_result(self) -> ResolveResult {
+                self.map($value_variant)
+            }
+        }
     };
 }
 
-pub struct WithThis;
-pub struct NoThis;
+macro_rules! impl_arg_value_from_context {
+    ($($type:ty),*) => {
+        $(
+            impl<'a, 'context> FromContext<'a, 'context> for $type {
+                fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+                where
+                    Self: Sized,
+                {
+                    arg_value_from_context(ctx).and_then(|v| FromValue::from_value(&v))
+                }
+            }
+        )*
+    };
+}
 
+#[macro_export]
 macro_rules! impl_handler {
-    // Base case: no more types, with a this
-    (@go_with_this $idx: expr, $call: expr, $ftx: ident, $this: ident, [], [$($args:tt)*]) => {
-        $call($this, $($args)*).into_resolve_result()
-    };
-
-    // Base case: no more types, without a this
-    (@go_without_this $idx: expr, $call: expr, $ftx: ident, [], [$($args:tt)*]) => {
-        $call($($args)*).into_resolve_result()
-    };
-
-    // Recurse for each ident, incrementing the index each time, with a this
-    (@go_with_this $idx: expr, $call: expr, $ftx: ident, $this: ident, [$head: ident, $($tail: ident,)*], [$($args:tt)*]) => {
-        impl_handler!(@go_with_this $idx + 1, $call, $ftx, $this, [$($tail,)*], [
-            $($args)*
+    ($($t:ty),*) => {
+        paste::paste! {
+            impl<F, $($t,)* R> Handler<($($t,)*)> for F
+            where
+                F: Fn($($t,)*) -> R + Clone,
+                $($t: for<'a, 'context> FromContext<'a, 'context>,)*
+                R: IntoResolveResult,
             {
-                let temp = $head::from(&$ftx.resolve(Argument($idx))?)?;
-                temp
-            },
-        ])
-    };
+                fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+                    $(
+                        let [<arg_ $t>] = $t::from_context(ftx)?;
+                    )*
+                    self($([<arg_ $t>],)*).into_resolve_result()
+                }
+            }
 
-    // Recurse for each ident, incrementing the index each time, without a this
-    (@go_without_this $idx: expr, $call: expr, $ftx: ident, [$head: ident, $($tail: ident,)*], [$($args:tt)*]) => {
-        impl_handler!(@go_without_this $idx + 1, $call, $ftx, [$($tail,)*], [
-            $($args)*
+            impl<F, $($t,)* R> Handler<(WithFunctionContext, $($t,)*)> for F
+            where
+                F: Fn(&FunctionContext, $($t,)*) -> R + Clone,
+                $($t: for<'a, 'context> FromContext<'a, 'context>,)*
+                R: IntoResolveResult,
             {
-                let temp = $head::from(&$ftx.resolve(Argument($idx))?)?;
-                temp
-            },
-        ])
-    };
-
-    // Main entry point.
-    ($($ty: ident),+ $(,)?) => {
-        impl<F, This, $($ty,)* R> Handler<(WithThis, This, $($ty,)*)> for F
-        where
-            F: Fn(This, $($ty,)*) -> R + Clone + 'static,
-            This: FromContext,
-            $( $ty: FromValue, )*
-            R: IntoResolveResult,
-        {
-            fn call(self, ftx: FunctionContext) -> ResolveResult {
-                let this = This::from_context(&ftx)?;
-                impl_handler!(@go_with_this 0, self, ftx, this, [$($ty,)*], [])
+                fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+                    $(
+                        let [<arg_ $t>] = $t::from_context(ftx)?;
+                    )*
+                    self(ftx, $([<arg_ $t>],)*).into_resolve_result()
+                }
             }
         }
-
-        impl<F, $($ty,)* R> Handler<(NoThis, $($ty,)*)> for F
-        where
-            F: Fn($($ty,)*) -> R + Clone + 'static,
-            $( $ty: FromValue, )*
-            R: IntoResolveResult,
-        {
-            fn call(self, ftx: FunctionContext) -> ResolveResult {
-                impl_handler!(@go_without_this 0, self, ftx, [$($ty,)*], [])
-            }
-        }
-    }
+    };
 }
 
 trait FromValue {
-    fn from(expr: &Value) -> Result<Self, ExecutionError>
+    fn from_value(value: &Value) -> Result<Self, ExecutionError>
     where
         Self: Sized;
 }
 
 impl FromValue for Value {
-    fn from(expr: &Value) -> Result<Self, ExecutionError>
+    fn from_value(value: &Value) -> Result<Self, ExecutionError>
     where
         Self: Sized,
     {
-        Ok(expr.clone())
+        Ok(value.clone())
     }
 }
 
-trait FromContext {
-    fn from_context(ctx: &FunctionContext) -> Result<Self, ExecutionError>
+trait FromContext<'a, 'context> {
+    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
     where
         Self: Sized;
 }
 
 pub struct This<T>(pub T);
 
-impl<T> FromContext for This<T>
+impl<'a, 'context, T> FromContext<'a, 'context> for This<T>
 where
     T: FromValue,
 {
-    fn from_context(ctx: &FunctionContext) -> Result<Self, ExecutionError>
+    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
     where
         Self: Sized,
     {
-        let value = ctx.target::<Value>()?;
-        Ok(This(T::from(value)?))
+        let value = ctx
+            .this::<Value>()
+            .cloned()
+            .or_else(|_| arg_value_from_context(ctx))?;
+        Ok(This(T::from_value(&value)?))
     }
 }
 
-trait IntoResolveResult {
+#[derive(Clone)]
+pub struct Identifier(pub Rc<String>);
+
+impl<'a, 'context> FromContext<'a, 'context> for Identifier {
+    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+    where
+        Self: Sized,
+    {
+        match arg_expr_from_context(ctx) {
+            Expression::Ident(ident) => Ok(Identifier(ident.clone())),
+            _ => {
+                // todo: better error
+                return Err(ExecutionError::UnexpectedType {
+                    got: "not an identifier".to_string(),
+                    want: "identifier".to_string(),
+                });
+            }
+        }
+    }
+}
+
+impl From<Identifier> for String {
+    fn from(value: Identifier) -> Self {
+        value.0.as_ref().clone()
+    }
+}
+
+#[derive(Clone)]
+pub struct List(pub Rc<Vec<Value>>);
+
+impl FromValue for List {
+    fn from_value(value: &Value) -> Result<Self, ExecutionError>
+    where
+        Self: Sized,
+    {
+        match value {
+            Value::List(list) => Ok(List(list.clone())),
+            _ => Err(ExecutionError::UnexpectedType {
+                got: format!("{:?}", value),
+                want: "list".to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Arguments(pub Rc<Vec<Value>>);
+
+impl<'a, 'context> FromContext<'a, 'context> for Arguments {
+    fn from_context(ctx: &'a mut FunctionContext) -> Result<Self, ExecutionError>
+    where
+        Self: Sized,
+    {
+        match ctx.resolve(AllArguments)? {
+            Value::List(list) => Ok(Arguments(list.clone())),
+            _ => todo!(),
+        }
+    }
+}
+
+impl<'a, 'context> FromContext<'a, 'context> for Value {
+    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+    where
+        Self: Sized,
+    {
+        arg_value_from_context(ctx)
+    }
+}
+
+impl<'a, 'context> FromContext<'a, 'context> for Expression {
+    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+    where
+        Self: Sized,
+    {
+        Ok(arg_expr_from_context(ctx))
+    }
+}
+
+fn arg_expr_from_context(ctx: &mut FunctionContext) -> Expression {
+    let idx = ctx.arg_idx;
+    ctx.arg_idx += 1;
+    ctx.args[idx].clone()
+}
+
+fn arg_value_from_context(ctx: &mut FunctionContext) -> Result<Value, ExecutionError> {
+    let idx = ctx.arg_idx;
+    ctx.arg_idx += 1;
+    ctx.resolve(Argument(idx))
+}
+
+pub trait IntoResolveResult {
     fn into_resolve_result(self) -> ResolveResult;
 }
 
@@ -173,72 +260,97 @@ impl_from_value!(bool, Value::Bool);
 impl_from_value!(Duration, Value::Duration);
 impl_from_value!(DateTime<FixedOffset>, Value::Timestamp);
 
-impl_handler!(T1);
-impl_handler!(T1, T2);
+impl_arg_value_from_context!(
+    i32,
+    u32,
+    f64,
+    Rc<String>,
+    Rc<Vec<u8>>,
+    bool,
+    Duration,
+    DateTime<FixedOffset>,
+    List
+);
 
-// // Implementation with target
-// impl<F, Target, A1, R> Handler<(WithTarget, Target, A1)> for F
+pub struct WithFunctionContext;
+
+impl_handler!();
+impl_handler!(C1);
+impl_handler!(C1, C2);
+impl_handler!(C1, C2, C3);
+impl_handler!(C1, C2, C3, C4);
+
+// impl<F, C1, C2, R> Handler<(C1, C2)> for F
 // where
-//     F: Fn(Target, A1) -> R + Clone + 'static,
-//     Target: FromContext,
-//     A1: FromValue,
+//     F: Fn(C1, C2) -> R + Clone,
+//     C1: for<'a, 'context> FromContext<'a, 'context>,
+//     C2: for<'a, 'context> FromContext<'a, 'context>,
 //     R: IntoResolveResult,
 // {
-//     fn call(self, ftx: FunctionContext) -> ResolveResult {
-//         let target = Target::from_context(&ftx)?;
-//         let arg = ftx.resolve(Argument(0))?;
-//         let arg = A1::from(&arg)?;
-//         self(target, arg).into_resolve_result()
-//     }
-// }
-//
-// // Implementation without target
-// impl<F, A1, R> Handler<(NoTarget, A1)> for F
-// where
-//     F: Fn(A1) -> R + Clone + 'static,
-//     A1: FromValue,
-//     R: IntoResolveResult,
-// {
-//     fn call(self, ftx: FunctionContext) -> ResolveResult {
-//         let arg = ftx.resolve(Argument(0))?;
-//         let arg = A1::from(&arg)?;
-//         self(arg).into_resolve_result()
-//     }
-// }
-//
-// // Implementation with target
-// impl<F, Target, A1, A2, R> Handler<(WithTarget, Target, A1, A2)> for F
-// where
-//     F: Fn(Target, A1, A2) -> R + Clone + 'static,
-//     Target: FromContext,
-//     A1: FromValue,
-//     A2: FromValue,
-//     R: IntoResolveResult,
-// {
-//     fn call(self, ftx: FunctionContext) -> ResolveResult {
-//         let target = Target::from_context(&ftx)?;
-//         let arg1 = ftx.resolve(Argument(0))?;
-//         let arg2 = ftx.resolve(Argument(1))?;
-//         let arg1 = A1::from(&arg1)?;
-//         let arg2 = A2::from(&arg2)?;
-//         self(target, arg1, arg2).into_resolve_result()
-//     }
-// }
-//
-// // Implementation without target
-// impl<F, A1, A2, R> Handler<(NoTarget, A1, A2)> for F
-// where
-//     F: Fn(A1, A2) -> R + Clone + 'static,
-//     A1: FromValue,
-//     A2: FromValue,
-//     R: IntoResolveResult,
-// {
-//     fn call(self, ftx: FunctionContext) -> ResolveResult {
-//         let arg1 = ftx.resolve(Argument(0))?;
-//         let arg2 = ftx.resolve(Argument(1))?;
-//         let arg1 = A1::from(&arg1)?;
-//         let arg2 = A2::from(&arg2)?;
+//     fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+//         let arg1 = C1::from_context(ftx)?;
+//         let arg2 = C2::from_context(ftx)?;
 //         self(arg1, arg2).into_resolve_result()
+//     }
+// }
+
+// impl<F, C1, C2, R> Handler<(WithFunctionContext, C1, C2)> for F
+// where
+//     F: Fn(&FunctionContext, C1, C2) -> R + Clone,
+//     C1: for<'a, 'context> FromContext<'a, 'context>,
+//     C2: for<'a, 'context> FromContext<'a, 'context>,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+//         let arg1 = C1::from_context(ftx)?;
+//         let arg2 = C2::from_context(ftx)?;
+//         self(ftx, arg1, arg2).into_resolve_result()
+//     }
+// }
+
+// impl<F, C1, R> Handler<(C1)> for F
+// where
+//     F: Fn(C1) -> R + Clone + 'static,
+//     C1: for<'a, 'context> FromContext<'a, 'context>,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+//         let arg1 = C1::from_context(ftx)?;
+//         self(arg1).into_resolve_result()
+//     }
+// }
+
+// impl<F, C1, C2, C3, R> Handler<(WithFunctionContext, C1, C2, C3)> for F
+// where
+//     F: Fn(&FunctionContext, C1, C2, C3) -> R + Clone + 'static,
+//     C1: for<'a, 'context> FromContext<'a, 'context>,
+//     C2: for<'a, 'context> FromContext<'a, 'context>,
+//     C3: for<'a, 'context> FromContext<'a, 'context>,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+//         let arg1 = C1::from_context(ftx)?;
+//         let arg2 = C2::from_context(ftx)?;
+//         let arg3 = C3::from_context(ftx)?;
+//         self(ftx, arg1, arg2, arg3).into_resolve_result()
+//     }
+// }
+
+// impl<F, C1, C2, C3, C4, R> Handler<(WithFunctionContext, C1, C2, C3, C4)> for F
+// where
+//     F: Fn(&FunctionContext, C1, C2, C3, C4) -> R + Clone + 'static,
+//     C1: for<'a, 'context> FromContext<'a, 'context>,
+//     C2: for<'a, 'context> FromContext<'a, 'context>,
+//     C3: for<'a, 'context> FromContext<'a, 'context>,
+//     C4: for<'a, 'context> FromContext<'a, 'context>,
+//     R: IntoResolveResult,
+// {
+//     fn call(self, ftx: &mut FunctionContext) -> ResolveResult {
+//         let arg1 = C1::from_context(ftx)?;
+//         let arg2 = C2::from_context(ftx)?;
+//         let arg3 = C3::from_context(ftx)?;
+//         let arg4 = C4::from_context(ftx)?;
+//         self(ftx, arg1, arg2, arg3, arg4).into_resolve_result()
 //     }
 // }
 
@@ -273,7 +385,7 @@ impl FunctionRegistry {
         self.routes.contains_key(name)
     }
 
-    fn call(&self, name: &str, ctx: &FunctionContext) -> ResolveResult {
+    fn call(&self, name: &str, ctx: &mut FunctionContext) -> ResolveResult {
         self.routes
             .get(name)
             .unwrap()
@@ -284,13 +396,13 @@ impl FunctionRegistry {
 
 pub trait Function {
     fn clone_box(&self) -> Box<dyn Function>;
-    fn into_callable<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> Box<dyn Callable + 'a>;
-    fn call_with_context<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> ResolveResult;
+    fn into_callable<'a>(self: Box<Self>, ctx: &'a mut FunctionContext) -> Box<dyn Callable + 'a>;
+    fn call_with_context<'a>(self: Box<Self>, ctx: &'a mut FunctionContext) -> ResolveResult;
 }
 
 pub struct HandlerFunction<H: Clone> {
     pub handler: H,
-    pub into_callable: for<'a> fn(H, &'a FunctionContext) -> Box<dyn Callable + 'a>,
+    pub into_callable: for<'a> fn(H, &'a mut FunctionContext) -> Box<dyn Callable + 'a>,
 }
 
 impl<H: Clone> Clone for HandlerFunction<H> {
@@ -310,11 +422,11 @@ where
         Box::new(self.clone())
     }
 
-    fn into_callable<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> Box<dyn Callable + 'a> {
+    fn into_callable<'a>(self: Box<Self>, ctx: &'a mut FunctionContext) -> Box<dyn Callable + 'a> {
         (self.into_callable)(self.handler, ctx)
     }
 
-    fn call_with_context<'a>(self: Box<Self>, ctx: &'a FunctionContext) -> ResolveResult {
+    fn call_with_context<'a>(self: Box<Self>, ctx: &'a mut FunctionContext) -> ResolveResult {
         self.into_callable(ctx).call()
     }
 }
@@ -324,14 +436,14 @@ pub trait Callable {
     fn call(&mut self) -> ResolveResult;
 }
 
-pub struct HandlerCallable<'a, H, T> {
+pub struct HandlerCallable<'a, 'context, H, T> {
     handler: H,
-    context: &'a FunctionContext<'a, 'a, 'a>,
+    context: &'a mut FunctionContext<'context>,
     _marker: PhantomData<fn() -> T>,
 }
 
-impl<'a, H, T> HandlerCallable<'a, H, T> {
-    pub fn new(handler: H, ctx: &'a FunctionContext) -> Self {
+impl<'a, 'context, H, T> HandlerCallable<'a, 'context, H, T> {
+    pub fn new(handler: H, ctx: &'a mut FunctionContext<'context>) -> Self {
         Self {
             handler,
             context: ctx,
@@ -340,30 +452,34 @@ impl<'a, H, T> HandlerCallable<'a, H, T> {
     }
 }
 
-impl<'a, H, T> Callable for HandlerCallable<'a, H, T>
+impl<'a, 'context, H, T> Callable for HandlerCallable<'a, 'context, H, T>
 where
     H: Handler<T> + Clone + 'static,
 {
     fn call(&mut self) -> ResolveResult {
-        self.handler.clone().call(self.context.clone())
+        self.handler.clone().call(self.context)
     }
 }
 
 pub trait Handler<T>: Clone {
-    fn call(self, ctx: FunctionContext) -> ResolveResult;
+    fn call(self, ctx: &mut FunctionContext) -> ResolveResult;
 }
 
 fn double(x: i32) -> i32 {
     x * 2
 }
 
-fn add(a: i32, b: i32) -> i32 {
-    a + b
+// fn add(a: i32, b: i32) -> i32 {
+//     a + b
+// }
+
+fn starts_with(ftx: &FunctionContext, This(this): This<Rc<String>>, prefix: Rc<String>) -> bool {
+    this.starts_with(prefix.as_str())
 }
 
-fn starts_with(This(this): This<Rc<String>>, name: Rc<String>) -> bool {
-    this.starts_with(name.as_str())
-}
+// fn starts_with(This(this): This<Rc<String>>, name: Rc<String>) -> bool {
+//     this.starts_with(name.as_str())
+// }
 
 #[test]
 fn test() {
@@ -372,16 +488,21 @@ fn test() {
     // router.add("add", add);
     router.add("starts_with", starts_with);
     let target = Value::String(Rc::new("foobar".to_string()));
-    let ctx = FunctionContext {
+    let mut ctx = FunctionContext {
         name: Rc::new("".to_string()),
-        target: Some(&target),
+        // target: Some(&target),
+        this: None,
         ptx: &Default::default(),
-        args: &[
-            Expression::Atom(Atom::String(Rc::new("foo".to_string()))),
+        args: vec![
+            Expression::Atom(Atom::String(Rc::new("foobar".to_string()))).into(),
+            Expression::Atom(Atom::String(Rc::new("foo".to_string()))).into(),
             // Expression::Atom(Atom::Int(20)),
-        ],
+            // Expression::Atom(Atom::Int(10)),
+        ]
+        .into(),
+        arg_idx: 0,
     };
 
-    let result = router.call("starts_with", &ctx);
+    let result = router.call("starts_with", &mut ctx);
     println!("{:?}", result)
 }

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -75,7 +75,8 @@ pub(crate) trait FromContext<'a, 'context> {
 /// # Using `This`
 /// ```
 /// # use std::rc::Rc;
-/// # use cel_interpreter::{This, Program, Context};
+/// # use cel_interpreter::{Program, Context};
+/// use cel_interpreter::extractors::This;
 /// # let mut context = Context::default();
 /// # context.add_function("startsWith", starts_with);
 ///
@@ -219,7 +220,8 @@ impl FromValue for List {
 /// ```
 ///
 /// ```rust
-/// # use cel_interpreter::{Arguments, Value};
+/// # use cel_interpreter::{Value};
+/// use cel_interpreter::extractors::Arguments;
 /// pub fn max(Arguments(args): Arguments) -> Value {
 ///     args.iter().max().cloned().unwrap_or(Value::Null).into()
 /// }
@@ -294,6 +296,7 @@ impl_handler!(C1, C2, C3, C4, C5);
 impl_handler!(C1, C2, C3, C4, C5, C6);
 impl_handler!(C1, C2, C3, C4, C5, C6, C7);
 impl_handler!(C1, C2, C3, C4, C5, C6, C7, C8);
+impl_handler!(C1, C2, C3, C4, C5, C6, C7, C8, C9);
 
 // Heavily inspired by https://users.rust-lang.org/t/common-data-type-for-functions-with-different-parameters-e-g-axum-route-handlers/90207/6
 // and https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c6744c27c2358ec1d1196033a0ec11e4

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -124,11 +124,13 @@ where
     where
         Self: Sized,
     {
-        let value = ctx
-            .this::<Value>()
-            .cloned()
-            .or_else(|_| arg_value_from_context(ctx))?;
-        Ok(This(T::from_value(&value)?))
+        if let Some(ref this) = ctx.this {
+            Ok(This(T::from_value(this)?))
+        } else {
+            let arg = arg_value_from_context(ctx)
+                .map_err(|_| ExecutionError::missing_argument_or_target())?;
+            Ok(This(T::from_value(&arg)?))
+        }
     }
 }
 

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -240,7 +240,7 @@ impl From<Value> for ResolveResult {
 }
 
 impl<'a> Value {
-    pub fn resolve_all(expr: &'a [Expression], ctx: &Context) -> ResolveResult {
+    pub fn resolve_all(expr: &[Expression], ctx: &Context) -> ResolveResult {
         let mut res = Vec::with_capacity(expr.len());
         for expr in expr {
             res.push(Value::resolve(expr, ctx)?);
@@ -408,22 +408,18 @@ impl<'a> Value {
                             if args.is_empty() {
                                 return Err(ExecutionError::MissingArgumentOrTarget);
                             }
-                            let ctx = FunctionContext {
-                                name,
-                                target: None,
-                                ptx: ctx,
-                                args,
-                            };
-                            func.call_with_context(&ctx)
+                            let mut ctx =
+                                FunctionContext::new(name.clone(), None, ctx, args.clone());
+                            func.call_with_context(&mut ctx)
                         }
                         Some(target) => {
-                            let ctx = FunctionContext {
-                                name,
-                                target: Some(&*target),
-                                ptx: ctx,
-                                args,
-                            };
-                            func.call_with_context(&ctx)
+                            let mut ctx = FunctionContext::new(
+                                name.clone(),
+                                Some(*target),
+                                ctx,
+                                args.clone(),
+                            );
+                            func.call_with_context(&mut ctx)
                         }
                     }
                 } else {

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -177,6 +177,12 @@ impl Value {
     }
 }
 
+impl From<&Value> for Value {
+    fn from(value: &Value) -> Self {
+        value.clone()
+    }
+}
+
 impl Eq for Value {}
 
 impl PartialOrd for Value {
@@ -220,6 +226,12 @@ impl From<Key> for Value {
             Key::Bool(v) => Value::Bool(v),
             Key::String(v) => Value::String(v),
         }
+    }
+}
+
+impl From<&Key> for Key {
+    fn from(key: &Key) -> Self {
+        key.clone()
     }
 }
 

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -453,9 +453,6 @@ impl<'a> Value {
                     let func = ctx.get_function(&**name).unwrap();
                     match target {
                         None => {
-                            if args.is_empty() {
-                                return Err(ExecutionError::MissingArgumentOrTarget);
-                            }
                             let mut ctx =
                                 FunctionContext::new(name.clone(), None, ctx, args.clone());
                             func.call_with_context(&mut ctx)

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -17,7 +17,7 @@ pub struct Map {
 }
 
 impl PartialOrd for Map {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+    fn partial_cmp(&self, _: &Self) -> Option<Ordering> {
         None
     }
 }

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -195,12 +195,12 @@ impl From<String> for Value {
         Value::String(v.into())
     }
 }
-
-impl From<Duration> for Value {
-    fn from(v: Duration) -> Self {
-        Value::Duration(v)
-    }
-}
+//
+// impl From<Duration> for Value {
+//     fn from(v: Duration) -> Self {
+//         Value::Duration(v)
+//     }
+// }
 
 // Convert Option<T> to Value
 impl<T: Into<Value>> From<Option<T>> for Value {
@@ -219,11 +219,11 @@ impl<K: Into<Key>, V: Into<Value>> From<HashMap<K, V>> for Value {
     }
 }
 
-impl_from!(
-    i32 => Value::Int,
-    f64 => Value::Float,
-    bool => Value::Bool
-);
+// impl_from!(
+//     i32 => Value::Int,
+//     f64 => Value::Float,
+//     bool => Value::Bool
+// );
 
 impl From<ExecutionError> for ResolveResult {
     fn from(value: ExecutionError) -> Self {

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -408,19 +408,23 @@ impl<'a> Value {
                             if args.is_empty() {
                                 return Err(ExecutionError::MissingArgumentOrTarget);
                             }
-                            func(FunctionContext {
+                            let ctx = FunctionContext {
                                 name,
                                 target: None,
                                 ptx: ctx,
                                 args,
-                            })
+                            };
+                            func.call_with_context(&ctx)
                         }
-                        Some(t) => func(FunctionContext {
-                            name,
-                            target: Some(&*t),
-                            ptx: ctx,
-                            args,
-                        }),
+                        Some(target) => {
+                            let ctx = FunctionContext {
+                                name,
+                                target: Some(&*target),
+                                ptx: ctx,
+                                args,
+                            };
+                            func.call_with_context(&ctx)
+                        }
                     }
                 } else {
                     unreachable!("FunctionCall without Value::Function - {:?}", self)

--- a/interpreter/src/resolvers.rs
+++ b/interpreter/src/resolvers.rs
@@ -1,0 +1,91 @@
+use crate::{ExecutionError, FunctionContext, ResolveResult, Value};
+use cel_parser::Expression;
+
+pub trait Resolver {
+    fn resolve(&self, ctx: &FunctionContext) -> ResolveResult;
+}
+
+/// Argument is a [`Resolver`] that resolves to the nth argument. Previously
+/// users would have to call a separate method `resolve_arg` and provide the
+/// arg that they wanted, but this is now handled by the [`Resolver`] trait.
+///
+/// # Example
+/// ```
+/// # use cel_interpreter::{Argument, Context, FunctionContext, Program, ResolveResult};
+/// #
+/// # let program = Program::compile("add(2, 3)").unwrap();
+/// # let mut context = Context::default();
+/// # context.add_function("add", add);
+/// #
+/// # let value = program.execute(&context).unwrap();
+/// # assert_eq!(value, 5.into());
+///
+/// /// The add function takes two arguments and returns their sum. We discard the first
+/// /// parameter because the add function is not a method, it is always called with two
+/// /// arguments.
+/// fn add(ftx: FunctionContext) -> ResolveResult {
+///     let a = ftx.resolve(Argument(0))?;
+///     let b = ftx.resolve(Argument(1))?;
+///     Ok(a + b)
+/// }
+/// ```
+pub struct Argument(pub usize);
+
+impl Resolver for Argument {
+    fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
+        let index = self.0;
+        let arg = ctx
+            .args
+            .get(index)
+            .ok_or(ExecutionError::invalid_argument_count(
+                index + 1,
+                ctx.args.len(),
+            ))?;
+        Value::resolve(arg, ctx.ptx)
+    }
+}
+
+pub struct ExpressionResolver<'a>(&'a Expression);
+
+impl Resolver for ExpressionResolver<'_> {
+    fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
+        Value::resolve(self.0, ctx.ptx)
+    }
+}
+
+impl<'a> From<&'a Expression> for ExpressionResolver<'a> {
+    fn from(expr: &'a Expression) -> Self {
+        ExpressionResolver(expr)
+    }
+}
+
+/// A resolver for all arguments passed to a function. Each argument will be
+/// resolved and then returned as a [`Value::List`]
+///
+/// # Example
+/// ```
+/// # use cel_interpreter::{Argument, Arguments, Context, FunctionContext, Program, ResolveResult};
+/// #
+/// # let program = Program::compile("list(1, 2, 3)").unwrap();
+/// # let mut context = Context::default();
+/// # context.add_function("list", list);
+/// #
+/// # let value = program.execute(&context).unwrap();
+/// # assert_eq!(value, vec![1, 2, 3].into());
+///
+/// /// The list function takes all the provided arguments and returns them as a list.
+/// fn list(ftx: FunctionContext) -> ResolveResult {
+///     ftx.resolve(Arguments)
+/// }
+/// ```
+pub struct Arguments;
+
+impl Resolver for Arguments {
+    fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
+        let mut args = Vec::with_capacity(ctx.args.len());
+        for arg in ctx.args {
+            args.push(Value::resolve(arg, ctx.ptx)?);
+        }
+        Ok(Value::List(args.into()))
+    }
+}

--- a/interpreter/src/resolvers.rs
+++ b/interpreter/src/resolvers.rs
@@ -5,6 +5,12 @@ pub trait Resolver {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult;
 }
 
+impl Resolver for Expression {
+    fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
+        Value::resolve(self, ctx.ptx)
+    }
+}
+
 /// Argument is a [`Resolver`] that resolves to the nth argument. Previously
 /// users would have to call a separate method `resolve_arg` and provide the
 /// arg that they wanted, but this is now handled by the [`Resolver`] trait.
@@ -23,7 +29,7 @@ pub trait Resolver {
 /// /// The add function takes two arguments and returns their sum. We discard the first
 /// /// parameter because the add function is not a method, it is always called with two
 /// /// arguments.
-/// fn add(ftx: FunctionContext) -> ResolveResult {
+/// fn add(ftx: &FunctionContext) -> ResolveResult {
 ///     let a = ftx.resolve(Argument(0))?;
 ///     let b = ftx.resolve(Argument(1))?;
 ///     Ok(a + b)
@@ -38,24 +44,10 @@ impl Resolver for Argument {
             .args
             .get(index)
             .ok_or(ExecutionError::invalid_argument_count(
-                index + 1,
+                (index + 1) as usize,
                 ctx.args.len(),
             ))?;
         Value::resolve(arg, ctx.ptx)
-    }
-}
-
-pub struct ExpressionResolver<'a>(&'a Expression);
-
-impl Resolver for ExpressionResolver<'_> {
-    fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
-        Value::resolve(self.0, ctx.ptx)
-    }
-}
-
-impl<'a> From<&'a Expression> for ExpressionResolver<'a> {
-    fn from(expr: &'a Expression) -> Self {
-        ExpressionResolver(expr)
     }
 }
 
@@ -64,7 +56,7 @@ impl<'a> From<&'a Expression> for ExpressionResolver<'a> {
 ///
 /// # Example
 /// ```
-/// # use cel_interpreter::{Argument, Arguments, Context, FunctionContext, Program, ResolveResult};
+/// # use cel_interpreter::{Argument, AllArguments, Context, FunctionContext, Program, ResolveResult};
 /// #
 /// # let program = Program::compile("list(1, 2, 3)").unwrap();
 /// # let mut context = Context::default();
@@ -74,16 +66,16 @@ impl<'a> From<&'a Expression> for ExpressionResolver<'a> {
 /// # assert_eq!(value, vec![1, 2, 3].into());
 ///
 /// /// The list function takes all the provided arguments and returns them as a list.
-/// fn list(ftx: FunctionContext) -> ResolveResult {
-///     ftx.resolve(Arguments)
+/// fn list(ftx: &FunctionContext) -> ResolveResult {
+///     ftx.resolve(AllArguments)
 /// }
 /// ```
-pub struct Arguments;
+pub struct AllArguments;
 
-impl Resolver for Arguments {
+impl Resolver for AllArguments {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
         let mut args = Vec::with_capacity(ctx.args.len());
-        for arg in ctx.args {
+        for arg in ctx.args.iter() {
             args.push(Value::resolve(arg, ctx.ptx)?);
         }
         Ok(Value::List(args.into()))


### PR DESCRIPTION
Originally this issue started with utilities for making it easier to write functions by providing function resolvers (shown below) but eventually evolved into Axum-style magic function parameters.

---

# Function value resolvers
Instead of 

```rust
let expr = ftx.arg(0)?;
let value = ftx.resolve(&expr)?;
// or
let value = ftx.resolve_arg(0)?;
```

Resolvers allow us to do things like
```rust
let value = ftx.resolve(Argument(0))?;
```
and hopefully a few more other handy things all from the same `resolve` function as this PR goes along.


The previous example was for single expression resolution. You can also resolve multiple. Instead of
```rust
let values = ftx.resolve_all();
```

we can do this using the same resolve function.
```rust
let values = ftx.resolve(Arguments)?;
```

# Target value resolvers
Previously you had to do
```rust
Ok(match ftx.target()? {
        Value::String(v) => v.parse::<f64>().map(Value::Float).unwrap(),
        ...
})
```

to unpack the target. Now you can ask for specific types by
```rust
let target = ftx.target::<Rc<String>>()?;
```

or just this if you need the old behavior.
```rust
Ok(match ftx.target::<Value>()? {
        Value::String(v) => v.parse::<f64>().map(Value::Float).unwrap(),
        ...
})
```
