### PR TITLE
Refactor code to hide parser internals

### DIFF
--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -1,6 +1,6 @@
 extern crate core;
 
-use cel_parser::parser::ExpressionParser;
+use cel_parser::parse;
 use std::convert::TryFrom;
 use std::rc::Rc;
 use thiserror::Error;
@@ -97,7 +97,7 @@ pub struct Program {
 
 impl Program {
     pub fn compile(source: &str) -> Result<Program, ParseError> {
-        match ExpressionParser::new().parse(source) {
+        match parse(source) {
             Ok(expression) => Ok(Program { expression }),
             // To-Do: Better error handling
             Err(e) => Err(ParseError {

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -3,4 +3,42 @@ use lalrpop_util::lalrpop_mod;
 pub mod ast;
 pub use ast::*;
 
+use std::fmt::Display;
+
 lalrpop_mod!(#[allow(clippy::all)] pub parser, "/cel.rs");
+
+
+#[derive(Debug)]
+pub struct ParseError {
+    msg: String,
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+pub fn parse(input: &str) -> Result<Expression, ParseError> {
+    // Wrap the internal parser function - whether larlpop or chumsky
+    println!("Parsing: >>>{}<<<", input);
+
+
+    // Example for a possible new chumsky based parser...
+    // parser().parse(input)
+    //     .into_result()
+    //     .map_err(|e|  {
+    //         ParseError {
+    //             msg: e.iter().map(|e| format!("{}", e)).collect::<Vec<_>>().join("\n")
+    //         }
+    //     })
+
+
+    // Existing Larlpop Parser:
+    crate::parser::ExpressionParser::new()
+        .parse(input)
+        .map_err(|e| ParseError {
+            msg: format!("{}", e),
+        })
+
+}


### PR DESCRIPTION
Small refactor in preparation for potentially switching the parser from lalrpop to chumsky as discussed in https://github.com/clarkmcc/cel-rust/pull/2#issuecomment-1665215220

The previous implementation exposed the 'ExpressionParser' from lalrpop directly which I've just replaced with a parse function.

I assume it is worth improving the error handling once the switch is complete.
