### PR TITLE
Updated integer types from 32-bit to 64-bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ library aims to be very simple to use, while still being fast, safe, and customi
 fn main() {
     let program = Program::compile("add(2, 3) == 5").unwrap();
     let mut context = Context::default();
-    context.add_function("add", |a: i32, b: i32| a + b);
+    context.add_function("add", |a: i64, b: i64| a + b);
     let value = program.execute(&context).unwrap();
     assert_eq!(value, true.into());
 }

--- a/example/src/functions.rs
+++ b/example/src/functions.rs
@@ -9,7 +9,7 @@ fn main() {
     let mut context = Context::default();
 
     // Add functions using closures
-    context.add_function("add", |a: i32, b: i32| a + b);
+    context.add_function("add", |a: i64, b: i64| a + b);
 
     // Add methods to a string type
     context.add_function("isEmpty", is_empty);
@@ -51,8 +51,8 @@ fn fail(ftx: &FunctionContext) -> ResolveResult {
 /// as arguments to a function, as well as the fact that any of these types can also
 /// be returned from a function.
 fn primitives(
-    _a: i32,
-    _b: u32,
+    _a: i64,
+    _b: u64,
     _c: f64,
     _d: bool,
     _e: Rc<String>,

--- a/interpreter/README.md
+++ b/interpreter/README.md
@@ -36,7 +36,7 @@ fn main() {
 
     // Add any variables or functions that the program will need
     let mut context = Context::default();
-    context.add_function("add", |a: i32, b: i32| a + b);
+    context.add_function("add", |a: i64, b: i64| a + b);
 
     // Run the program
     let value = program.execute(&context).unwrap();

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -68,7 +68,7 @@ impl<'context> FunctionContext<'context> {
 /// ```skip
 /// size([1, 2, 3]) == 3
 /// ```
-pub fn size(ftx: &FunctionContext, value: Value) -> Result<i32> {
+pub fn size(ftx: &FunctionContext, value: Value) -> Result<i64> {
     let size = match value {
         Value::List(l) => l.len(),
         Value::Map(m) => m.map.len(),
@@ -76,7 +76,7 @@ pub fn size(ftx: &FunctionContext, value: Value) -> Result<i32> {
         Value::Bytes(b) => b.len(),
         value => return Err(ftx.error(&format!("cannot determine the size of {:?}", value))),
     };
-    Ok(size as i32)
+    Ok(size as i64)
 }
 
 /// Returns true if the target contains the provided argument. The actual behavior

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -176,7 +176,7 @@ mod tests {
         // Test that we can merge two maps
         assert_output(
             "{'a': 1} + {'a': 2, 'b': 3}",
-            Ok(HashMap::from([("a", 2i64), ("b", 3i64)]).into()),
+            Ok(HashMap::from([("a", 2), ("b", 3)]).into()),
         );
     }
 
@@ -216,7 +216,7 @@ mod tests {
 
         for (name, script, error) in tests {
             let mut ctx = Context::default();
-            ctx.add_variable("foo", HashMap::from([("bar", 1i64)]));
+            ctx.add_variable("foo", HashMap::from([("bar", 1)]));
             let res = test_script(script, Some(ctx));
             assert_eq!(res, error.into(), "{}", name);
         }

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -154,8 +154,8 @@ mod tests {
     fn variables() {
         fn assert_output(script: &str, expected: ResolveResult) {
             let mut ctx = Context::default();
-            ctx.add_variable("foo", HashMap::from([("bar", 1)]));
-            ctx.add_variable("arr", vec![1i32, 2, 3]);
+            ctx.add_variable("foo", HashMap::from([("bar", 1i64)]));
+            ctx.add_variable("arr", vec![1i64, 2, 3]);
             ctx.add_variable("str", "foobar".to_string());
             assert_eq!(test_script(script, Some(ctx)), expected);
         }
@@ -176,7 +176,7 @@ mod tests {
         // Test that we can merge two maps
         assert_output(
             "{'a': 1} + {'a': 2, 'b': 3}",
-            Ok(HashMap::from([("a", 2), ("b", 3)]).into()),
+            Ok(HashMap::from([("a", 2i64), ("b", 3i64)]).into()),
         );
     }
 
@@ -216,7 +216,7 @@ mod tests {
 
         for (name, script, error) in tests {
             let mut ctx = Context::default();
-            ctx.add_variable("foo", HashMap::from([("bar", 1)]));
+            ctx.add_variable("foo", HashMap::from([("bar", 1i64)]));
             let res = test_script(script, Some(ctx));
             assert_eq!(res, error.into(), "{}", name);
         }

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -8,8 +8,8 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 impl_conversions!(
-    i32 => Value::Int,
-    u32 => Value::UInt,
+    i64 => Value::Int,
+    u64 => Value::UInt,
     f64 => Value::Float,
     Rc<String> => Value::String,
     Rc<Vec<u8>> => Value::Bytes,
@@ -18,6 +18,12 @@ impl_conversions!(
     DateTime<FixedOffset> => Value::Timestamp,
     Rc<Vec<Value>> => Value::List
 );
+
+impl From<i32> for Value {
+    fn from(value: i32) -> Self {
+        Value::Int(value as i64)
+    }
+}
 
 /// Describes any type that can be converted from a [`Value`] into itself.
 /// This is commonly used to convert from [`Value`] into primitive types,

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -24,8 +24,8 @@ impl PartialOrd for Map {
 
 #[derive(Debug, Eq, PartialEq, Hash, Ord, Clone, PartialOrd)]
 pub enum Key {
-    Int(i32),
-    Uint(u32),
+    Int(i64),
+    Uint(u64),
     Bool(bool),
     String(Rc<String>),
 }
@@ -56,14 +56,14 @@ impl From<bool> for Key {
     }
 }
 
-impl From<i32> for Key {
-    fn from(v: i32) -> Self {
+impl From<i64> for Key {
+    fn from(v: i64) -> Self {
         Key::Int(v)
     }
 }
 
-impl From<u32> for Key {
-    fn from(v: u32) -> Self {
+impl From<u64> for Key {
+    fn from(v: u64) -> Self {
         Key::Uint(v)
     }
 }
@@ -106,8 +106,8 @@ pub enum Value {
     Function(Rc<String>, Option<Box<Value>>),
 
     // Atoms
-    Int(i32),
-    UInt(u32),
+    Int(i64),
+    UInt(u64),
     Float(f64),
     String(Rc<String>),
     Bytes(Rc<Vec<u8>>),

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -57,8 +57,8 @@ pub enum Member {
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Atom {
-    Int(i32),
-    UInt(u32),
+    Int(i64),
+    UInt(u64),
     Float(f64),
     String(Rc<String>),
     Bytes(Rc<Vec<u8>>),

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -92,9 +92,9 @@ RelationOp: RelationOp = {
 Atom: Atom = {
     // Integer literals. Annoying to parse :/
     r"-?[0-9]+" => Atom::Int(<>.parse().unwrap()),
-    r"-?0[xX]([0-9a-fA-F]+)" => Atom::Int(i32::from_str_radix(<>, 16).unwrap()),
+    r"-?0[xX]([0-9a-fA-F]+)" => Atom::Int(i64::from_str_radix(<>, 16).unwrap()),
     r"-?[0-9]+ [uU]" => Atom::UInt(<>.parse().unwrap()),
-    r"-?0[xX]([0-9a-fA-F]+) [uU]" => Atom::UInt(u32::from_str_radix(<>, 16).unwrap()),
+    r"-?0[xX]([0-9a-fA-F]+) [uU]" => Atom::UInt(u64::from_str_radix(<>, 16).unwrap()),
 
     // Float with decimals and optional exponent
     r"([-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?)" => Atom::Float(<>.parse().unwrap()),


### PR DESCRIPTION
Changes CEL UInt and Int to use 64 bits instead of 32 as per the [spec](https://github.com/google/cel-spec/blob/master/doc/langdef.md#numeric-values):
> CEL supports only 64-bit integers and 64-bit IEEE double-precision floating-point.

I added/kept a conversion from i32 to Value, but couldn't use the `impl_conversions` macro so I haven't implemented for Option or any of the ResolveResult versions.