### PR TITLE
Feature/remove double negation from ast

### DIFF
--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -357,16 +357,9 @@ impl<'a> Value {
                 let expr = Value::resolve(expr, ctx)?;
                 match op {
                     UnaryOp::Not => Value::Bool(!expr.to_bool()),
-                    UnaryOp::DoubleNot => Value::Bool(expr.to_bool()),
-                    UnaryOp::Minus => match expr {
+                    UnaryOp::Neg => match expr {
                         Value::Int(i) => Value::Int(-i),
                         Value::Float(i) => Value::Float(-i),
-                        _ => unimplemented!(),
-                    },
-                    UnaryOp::DoubleMinus => match expr {
-                        Value::Int(_) => expr,
-                        Value::UInt(_) => expr,
-                        Value::Float(_) => expr,
                         _ => unimplemented!(),
                     },
                 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -23,9 +23,7 @@ pub enum ArithmeticOp {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum UnaryOp {
     Not,
-    DoubleNot,
-    Minus,
-    DoubleMinus,
+    Neg,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -74,9 +74,7 @@ ArithmeticOp: ArithmeticOp = { // (3)
 
 UnaryOp: UnaryOp = {
     "!" => UnaryOp::Not,
-    "!!" => UnaryOp::DoubleNot,
-    "-" => UnaryOp::Minus,
-    "--" => UnaryOp::DoubleMinus,
+    "-" => UnaryOp::Neg,
 }
 
 RelationOp: RelationOp = {
@@ -91,10 +89,10 @@ RelationOp: RelationOp = {
 
 Atom: Atom = {
     // Integer literals. Annoying to parse :/
-    r"-?[0-9]+" => Atom::Int(<>.parse().unwrap()),
-    r"-?0[xX]([0-9a-fA-F]+)" => Atom::Int(i64::from_str_radix(<>, 16).unwrap()),
-    r"-?[0-9]+ [uU]" => Atom::UInt(<>.parse().unwrap()),
-    r"-?0[xX]([0-9a-fA-F]+) [uU]" => Atom::UInt(u64::from_str_radix(<>, 16).unwrap()),
+    r"[0-9]+" => Atom::Int(<>.parse().unwrap()),
+    r"0[xX]([0-9a-fA-F]+)" => Atom::Int(i64::from_str_radix(<>, 16).unwrap()),
+    r"[0-9]+ [uU]" => Atom::UInt(<>.parse().unwrap()),
+    r"0[xX]([0-9a-fA-F]+) [uU]" => Atom::UInt(u64::from_str_radix(<>, 16).unwrap()),
 
     // Float with decimals and optional exponent
     r"([-+]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?)" => Atom::Float(<>.parse().unwrap()),

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -212,10 +212,15 @@ mod tests {
     #[test]
     fn test_parser_bool_unary_ops_repeated() {
         assert_eq!(
-            parse("!!true"),
+            parse("!(!true)"),  // Parens to help LALRPOP
             (Unary(
-                UnaryOp::DoubleNot,
-                Box::new(Expression::Atom(Atom::Bool(true))),
+                UnaryOp::Not,
+                Box::new(
+                    Expression::Unary(
+                        UnaryOp::Not,
+                        Box::new(Expression::Atom(Atom::Bool(true)))
+                    )
+                ),
             ))
         );
     }
@@ -224,7 +229,7 @@ mod tests {
     fn delimited_expressions() {
         assert_parse_eq(
             "(-((1)))",
-            Unary(UnaryOp::Minus, Box::new(Expression::Atom(Atom::Int(1)))),
+            Unary(UnaryOp::Neg, Box::new(Expression::Atom(Atom::Int(1)))),
         );
     }
 


### PR DESCRIPTION
Removes the DoubleMinus and DoubleNot from the AST.

Also after noting in the spec:
> We only support positive, decimal integer literals; negative integers are produced by the unary negation operator.

I removed the `-?` before the integer and unsigned integer parsing.

One case is no longer handled correctly by the LARLPOP parser `!!member`. I've changed the test for now to `!(!...` hoping you know how to handle this properly?