### PR TITLE
Implement string parser

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -12,5 +12,12 @@ categories = ["parsing", "cel"]
 lalrpop-util = { version = "0.19.1", features = ["lexer"] }
 regex = "1.4.2"
 
+[dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports"] }
+
 [build-dependencies]
 lalrpop = { version = "0.19.1", features = ["lexer"] }
+
+[[bench]]
+name = "runtime"
+harness = false

--- a/parser/benches/runtime.rs
+++ b/parser/benches/runtime.rs
@@ -1,0 +1,21 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use cel_parser::parse_string;
+
+pub fn parse_string_benchmark(c: &mut Criterion) {
+    let expressions = vec![
+        ("text", "\"text\""),
+        ("raw", "r\"text\""),
+        ("single unicode escape sequence", "\"\\U0001f431\""),
+        ("single hex escape sequence", "\"\\x0D\""),
+        ("single oct escape sequence", "\"\\015\""),
+    ];
+
+    for (name, expr) in black_box(&expressions) {
+        c.bench_function(name, |b| {
+            b.iter(|| parse_string(expr))
+        });
+    }
+}
+
+criterion_group!(benches, parse_string_benchmark);
+criterion_main!(benches);

--- a/parser/benches/runtime.rs
+++ b/parser/benches/runtime.rs
@@ -1,5 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use cel_parser::parse_string;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 pub fn parse_string_benchmark(c: &mut Criterion) {
     let expressions = vec![
@@ -11,9 +11,7 @@ pub fn parse_string_benchmark(c: &mut Criterion) {
     ];
 
     for (name, expr) in black_box(&expressions) {
-        c.bench_function(name, |b| {
-            b.iter(|| parse_string(expr))
-        });
+        c.bench_function(name, |b| b.iter(|| parse_string(expr)));
     }
 }
 

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -1,4 +1,4 @@
-use crate::{RelationOp, ArithmeticOp, Expression, UnaryOp, Member, Atom};
+use crate::{RelationOp, ArithmeticOp, Expression, UnaryOp, Member, Atom, parse_string};
 use std::sync::Arc;
 
 grammar;
@@ -138,11 +138,13 @@ Atom: Atom = {
     // the LALRPOP parser.
 
     // Double quoted string
-    r#""(\\.|[^"\n])*""# => Atom::String(Arc::from(<>[1..<>.len()-1].to_string())),
+    r#"".*""# => Atom::String(parse_string(<>).unwrap().into()),
+    r#"[rR]".*""# => Atom::String(parse_string(<>).unwrap().into()),
     // r#""""(\\.|[^"{3}])*""""# => Atom::String(<>.to_string().into()),
 
     // Single quoted string
-    r#"'(\\.|[^'\n])*'"# => Atom::String(Arc::from(<>[1..<>.len()-1].to_string())),
+    r#"'.*'"# => Atom::String(parse_string(<>).unwrap().into()),
+    r#"[rR]'.*'"# => Atom::String(parse_string(<>).unwrap().into()),
     // r#"'''(\\.|[^'{3}])*'''"# => Atom::String(<>.to_string().into()),
 
     // Double quoted bytes

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -138,13 +138,22 @@ Atom: Atom = {
     // the LALRPOP parser.
 
     // Double quoted string
-    r#"".*""# => Atom::String(parse_string(<>).unwrap().into()),
-    r#"[rR]".*""# => Atom::String(parse_string(<>).unwrap().into()),
+    // I used ChatGPT to come up with this pattern and the explanation is as follows:
+    //   1. `"`: Match the opening double quote.
+    //   2. `([^"\\]*(?:\\.[^"\\]*)*)`: This is the main part of the regex which matches the content inside the double quotes.
+    //     a. `[^"\\]*`: Match any sequence of characters that are neither a double quote nor a backslash.
+    //     b. `(?:\\.[^"\\]*)*`: This part matches an escaped character followed by any sequence of characters that are
+    //        neither a double quote nor a backslash. It uses a non-capturing group (?:...) to repeat the pattern.
+    //        This handles sequences like \", \\, or any other escaped character.
+    //   3. `"`: Match the closing double quote.
+    r#""([^"\\]*(?:\\.[^"\\]*)*)""# => Atom::String(parse_string(<>).unwrap().into()),
+    r#"[rR]"([^"\\]*(?:\\.[^"\\]*)*)""# => Atom::String(parse_string(<>).unwrap().into()),
     // r#""""(\\.|[^"{3}])*""""# => Atom::String(<>.to_string().into()),
 
     // Single quoted string
-    r#"'.*'"# => Atom::String(parse_string(<>).unwrap().into()),
-    r#"[rR]'.*'"# => Atom::String(parse_string(<>).unwrap().into()),
+    // Uses similar regex as above, but replace double quote with a single one
+    r#"'([^'\\]*(?:\\.[^'\\]*)*)'"# => Atom::String(parse_string(<>).unwrap().into()),
+    r#"[rR]'([^'\\]*(?:\\.[^'\\]*)*)'"# => Atom::String(parse_string(<>).unwrap().into()),
     // r#"'''(\\.|[^'{3}])*'''"# => Atom::String(<>.to_string().into()),
 
     // Double quoted bytes

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -3,6 +3,9 @@ use lalrpop_util::lalrpop_mod;
 pub mod ast;
 pub use ast::*;
 
+pub mod parse;
+pub use parse::*;
+
 use std::fmt::Display;
 
 lalrpop_mod!(#[allow(clippy::all)] pub parser, "/cel.rs");

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -28,7 +28,7 @@ pub enum ParseError {
 }
 
 /// Source error type of [ParseError::InvalidUnicode](ParseError::InvalidUnicode).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ParseUnicodeError {
     // #[error("could not parse {string} as u32 hex: {source}")]
     ParseHexFailed {
@@ -205,21 +205,20 @@ fn parse_quoted_string(
                                 _ => unreachable!(),
                             };
 
-                            parse_unicode_hex(length, &mut chars)
-                                .map_err(|x| ParseError::InvalidUnicode {
-                                    source: x,
+                            parse_unicode_hex(length, &mut chars).map_err(|x| {
+                                ParseError::InvalidUnicode {
+                                    source: x.clone(),
                                     index: idx,
                                     string: String::from(s),
-                                })
-                                .unwrap()
+                                }
+                            })?
                         }
                         n if ('0'..='3').contains(&n) => parse_unicode_oct(&n, &mut chars)
                             .map_err(|x| ParseError::InvalidUnicode {
-                                source: x,
+                                source: x.clone(),
                                 index: idx,
                                 string: String::from(s),
-                            })
-                            .unwrap(),
+                            })?,
                         _ => {
                             return Err(ParseError::InvalidEscape {
                                 escape: format!("{}{}", c, c2),

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -202,33 +202,23 @@ fn parse_quoted_string(s: &str, mut chars: &mut Enumerate<Chars>, mut res: Strin
                             }
                         },
                         '`' => res.push('`'),
-                        'x' => res.push(
-                            parse_unicode_hex(2, &mut chars).map_err(|x| {
-                                ParseError::InvalidUnicode {
-                                    source: x,
-                                    index: idx,
-                                    string: String::from(s),
-                                }
-                            }).unwrap()
-                        ),
-                        'u' => res.push(
-                            parse_unicode_hex(4, &mut chars).map_err(|x| {
-                                ParseError::InvalidUnicode {
-                                    source: x,
-                                    index: idx,
-                                    string: String::from(s),
-                                }
-                            }).unwrap()
-                        ),
-                        'U' => res.push(
-                            parse_unicode_hex(8, &mut chars).map_err(|x| {
-                                ParseError::InvalidUnicode {
-                                    source: x,
-                                    index: idx,
-                                    string: String::from(s),
-                                }
-                            }).unwrap()
-                        ),
+                        'x' | 'u' | 'U' => {
+                            let length = match c2 {
+                                'x' => 2,
+                                'u' => 4,
+                                'U' => 8,
+                                _ => unreachable!(),
+                            };
+                            res.push(
+                                parse_unicode_hex(length, &mut chars).map_err(|x| {
+                                    ParseError::InvalidUnicode {
+                                        source: x,
+                                        index: idx,
+                                        string: String::from(s),
+                                    }
+                                }).unwrap()
+                            )
+                        },
                         x if ('0'..='3').contains(&x) => res.push(
                             parse_unicode_oct(&x, &mut chars).map_err(|x| {
                                 ParseError::InvalidUnicode {
@@ -296,9 +286,7 @@ fn parse_unicode_hex<I>(length: usize, chars: &mut I) -> Result<char, ParseUnico
             string: unicode_seq,
         })
         .and_then(|u| {
-            char::from_u32(u)
-                .and_then(|c| Some(c))
-                .ok_or_else(|| ParseUnicodeError::ParseUnicodeFailed { value: u })
+            char::from_u32(u).ok_or(ParseUnicodeError::ParseUnicodeFailed { value: u })
         })
 }
 
@@ -317,9 +305,7 @@ fn parse_unicode_oct<I>(first_char: &char, chars: &mut I) -> Result<char, ParseU
         })
         .and_then(|u| {
             if u <= 255 {
-                char::from_u32(u)
-                    .and_then(|c| Some(c))
-                    .ok_or_else(|| ParseUnicodeError::ParseUnicodeFailed { value: u })
+                char::from_u32(u).ok_or(ParseUnicodeError::ParseUnicodeFailed { value: u })
             } else {
                 Err(ParseUnicodeError::ParseUnicodeFailed { value: u })
             }

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -1,0 +1,241 @@
+use std::num::ParseIntError;
+
+/// Error type of [unescape](unescape).
+#[derive(Debug, PartialEq)]
+pub enum ParseError {
+    // #[error("invalid escape {escape} at {index} in {string}")]
+    InvalidEscape {
+        escape: String,
+        index: usize,
+        string: String,
+    },
+    // #[error("\\u could not be parsed at {index} in {string}: {source}")]
+    InvalidUnicode {
+        // #[source]
+        source: ParseUnicodeError,
+        index: usize,
+        string: String,
+    },
+}
+
+/// Source error type of [ParseError::InvalidUnicode](ParseError::InvalidUnicode).
+#[derive(Debug, PartialEq)]
+pub enum ParseUnicodeError {
+    // #[error("could not parse {string} as u32 hex: {source}")]
+    ParseHexFailed {
+        // #[source]
+        source: ParseIntError,
+        string: String,
+    },
+    ParseOctFailed {
+        // #[source]
+        source: ParseIntError,
+        string: String,
+    },
+    // #[error("could not parse {value} as a unicode char")]
+    ParseUnicodeFailed { value: u32 },
+}
+
+/// Parse the provided quoted string.
+/// This function was adopted from [snailquote](https://docs.rs/snailquote/latest/snailquote/).
+///
+/// # Details
+///
+/// Parses a single or double quoted string and interprets escape sequences such as
+/// '\n', '\r', '\'', etc.
+///
+/// Supports raw strings prefixed with `r` or `R` in which case all escape sequences are ignored.///
+///
+/// The full set of supported escapes between quotes may be found below:
+///
+/// | Escape     | Code       | Description                              |
+/// |------------|------------|------------------------------------------|
+/// | \a         | 0x07       | Bell                                     |
+/// | \b         | 0x08       | Backspace                                |
+/// | \v         | 0x0B       | Vertical tab                             |
+/// | \f         | 0x0C       | Form feed                                |
+/// | \n         | 0x0A       | Newline                                  |
+/// | \r         | 0x0D       | Carriage return                          |
+/// | \t         | 0x09       | Tab                                      |
+/// | \\         | 0x5C       | Backslash                                |
+/// | \?         | 0x??       | Question mark                            |
+/// | \"         | 0x22       | Double quote                             |
+/// | \'         | 0x27       | Single quote                             |
+/// | \`         | 0x??       | Backtick                                 |
+/// | \xDD       | 0xDD       | Unicode character with hex code DD       |
+/// | \uDDDD     | 0xDDDD     | Unicode character with hex code DDDD     |
+/// | \UDDDDDDDD | 0xDDDDDDDD | Unicode character with hex code DDDDDDDD |
+/// | \DDD       | 0DDD       | Unicode character with octal code DDD    |
+///
+/// # Errors
+///
+/// The returned result can display a human readable error if the string cannot be parsed as a
+/// valid quoted string.
+///
+
+pub fn parse_string(s: &str) -> Result<String, ParseError> {
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut in_raw_string = false;
+
+    let mut chars = s.chars().enumerate();
+    let mut res = String::with_capacity(s.len());
+
+    while let Some((idx, c)) = chars.next() {
+        let in_quotes = in_single_quotes || in_double_quotes;
+
+        if !in_quotes && (c == 'r' || c == 'R') {
+            in_raw_string = true;
+            continue;
+        } else if c == '\\' && !in_raw_string {
+            if in_quotes {
+                match chars.next() {
+                    None => {
+                        return Err(ParseError::InvalidEscape {
+                            escape: format!("{}", c),
+                            index: idx,
+                            string: String::from(s),
+                        });
+                    }
+                    Some((idx, c2)) => {
+                        let s = match c2 {
+                            'a' => String::from("\u{07}"),
+                            'b' => String::from("\u{08}"),
+                            'v' => String::from("\u{0B}"),
+                            'f' => String::from("\u{0C}"),
+                            'n' => String::from("\n"),
+                            'r' => String::from("\r"),
+                            't' => String::from("\t"),
+                            '\\' => String::from("\\"),
+                            '?' => String::from("?"),
+                            '\'' => {
+                                if in_double_quotes {
+                                    String::from("\\'")
+                                } else {
+                                    String::from("'")
+                                }
+                            },
+                            '"' => {
+                                if in_single_quotes {
+                                    String::from("\\\"")
+                                } else {
+                                    String::from("\"")
+                                }
+                            },
+                            '`' => String::from("`"),
+                            'x' => parse_unicode_hex(2, &mut chars).map_err(|x| {
+                                ParseError::InvalidUnicode {
+                                    source: x,
+                                    index: idx,
+                                    string: String::from(s),
+                                }
+                            }).unwrap(),
+                            'u' => parse_unicode_hex(4, &mut chars).map_err(|x| {
+                                ParseError::InvalidUnicode {
+                                    source: x,
+                                    index: idx,
+                                    string: String::from(s),
+                                }
+                            }).unwrap(),
+                            'U' => parse_unicode_hex(8, &mut chars).map_err(|x| {
+                                ParseError::InvalidUnicode {
+                                    source: x,
+                                    index: idx,
+                                    string: String::from(s),
+                                }
+                            }).unwrap(),
+                            x if ('0'..='3').contains(&x) => parse_unicode_oct(&x, &mut chars).map_err(|x| {
+                                ParseError::InvalidUnicode {
+                                    source: x,
+                                    index: idx,
+                                    string: String::from(s),
+                                }
+                            }).unwrap(),
+                            _ => {
+                                return Err(ParseError::InvalidEscape {
+                                    escape: format!("{}{}", c, c2),
+                                    index: idx,
+                                    string: String::from(s),
+                                });
+                            }
+                        };
+                        res.push_str(s.as_str());
+                        continue;
+                    }
+                };
+            } else {
+                return Err(ParseError::InvalidEscape {
+                    escape: format!("{}", c),
+                    index: idx,
+                    string: String::from(s),
+                });
+            }
+        }
+        else if c == '\'' {
+            if in_double_quotes {
+                res.push(c);
+                continue
+            }
+
+            in_single_quotes = !in_single_quotes;
+            continue;
+        } else if c == '"' {
+            if in_single_quotes {
+                res.push(c);
+                continue
+            }
+
+            in_double_quotes = !in_double_quotes;
+            continue;
+        }
+
+        res.push(c);
+    }
+
+    Ok(res)
+}
+
+fn parse_unicode_hex<I>(length: usize, chars: &mut I) -> Result<String, ParseUnicodeError>
+    where
+        I: Iterator<Item = (usize, char)>,
+{
+    let unicode_seq: String = chars
+        .take(length)
+        .map(|(_, c)| c)
+        .collect();
+
+    u32::from_str_radix(&unicode_seq, 16)
+        .map_err(|e| ParseUnicodeError::ParseHexFailed {
+            source: e,
+            string: unicode_seq,
+        })
+        .and_then(|u| {
+            char::from_u32(u)
+                .and_then(|c| Some(c.to_string()))
+                .ok_or_else(|| ParseUnicodeError::ParseUnicodeFailed { value: u })
+        })
+}
+
+fn parse_unicode_oct<I>(first_char: &char, chars: &mut I) -> Result<String, ParseUnicodeError>
+    where
+        I: Iterator<Item = (usize, char)>,
+{
+    let mut unicode_seq: String = String::with_capacity(3);
+    unicode_seq.push(*first_char);
+    chars.take(2).for_each(|(_, c)| unicode_seq.push(c));
+
+    u32::from_str_radix(&unicode_seq, 8)
+        .map_err(|e| ParseUnicodeError::ParseOctFailed {
+            source: e,
+            string: unicode_seq,
+        })
+        .and_then(|u| {
+            if u <= 255 {
+                char::from_u32(u)
+                    .and_then(|c| Some(c.to_string()))
+                    .ok_or_else(|| ParseUnicodeError::ParseUnicodeFailed { value: u })
+            } else {
+                Err(ParseUnicodeError::ParseUnicodeFailed { value: u })
+            }
+        })
+}

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -202,41 +202,41 @@ fn parse_quoted_string(s: &str, mut chars: &mut Enumerate<Chars>, mut res: Strin
                             }
                         },
                         '`' => res.push('`'),
-                        'x' => res.push_str(
+                        'x' => res.push(
                             parse_unicode_hex(2, &mut chars).map_err(|x| {
                                 ParseError::InvalidUnicode {
                                     source: x,
                                     index: idx,
                                     string: String::from(s),
                                 }
-                            }).unwrap().as_str()
+                            }).unwrap()
                         ),
-                        'u' => res.push_str(
+                        'u' => res.push(
                             parse_unicode_hex(4, &mut chars).map_err(|x| {
                                 ParseError::InvalidUnicode {
                                     source: x,
                                     index: idx,
                                     string: String::from(s),
                                 }
-                            }).unwrap().as_str()
+                            }).unwrap()
                         ),
-                        'U' => res.push_str(
+                        'U' => res.push(
                             parse_unicode_hex(8, &mut chars).map_err(|x| {
                                 ParseError::InvalidUnicode {
                                     source: x,
                                     index: idx,
                                     string: String::from(s),
                                 }
-                            }).unwrap().as_str()
+                            }).unwrap()
                         ),
-                        x if ('0'..='3').contains(&x) => res.push_str(
+                        x if ('0'..='3').contains(&x) => res.push(
                             parse_unicode_oct(&x, &mut chars).map_err(|x| {
                                 ParseError::InvalidUnicode {
                                     source: x,
                                     index: idx,
                                     string: String::from(s),
                                 }
-                            }).unwrap().as_str()
+                            }).unwrap()
                         ),
                         _ => {
                             return Err(ParseError::InvalidEscape {
@@ -281,7 +281,7 @@ fn parse_quoted_string(s: &str, mut chars: &mut Enumerate<Chars>, mut res: Strin
     Ok(res)
 }
 
-fn parse_unicode_hex<I>(length: usize, chars: &mut I) -> Result<String, ParseUnicodeError>
+fn parse_unicode_hex<I>(length: usize, chars: &mut I) -> Result<char, ParseUnicodeError>
     where
         I: Iterator<Item = (usize, char)>,
 {
@@ -297,12 +297,12 @@ fn parse_unicode_hex<I>(length: usize, chars: &mut I) -> Result<String, ParseUni
         })
         .and_then(|u| {
             char::from_u32(u)
-                .and_then(|c| Some(c.to_string()))
+                .and_then(|c| Some(c))
                 .ok_or_else(|| ParseUnicodeError::ParseUnicodeFailed { value: u })
         })
 }
 
-fn parse_unicode_oct<I>(first_char: &char, chars: &mut I) -> Result<String, ParseUnicodeError>
+fn parse_unicode_oct<I>(first_char: &char, chars: &mut I) -> Result<char, ParseUnicodeError>
     where
         I: Iterator<Item = (usize, char)>,
 {
@@ -318,7 +318,7 @@ fn parse_unicode_oct<I>(first_char: &char, chars: &mut I) -> Result<String, Pars
         .and_then(|u| {
             if u <= 255 {
                 char::from_u32(u)
-                    .and_then(|c| Some(c.to_string()))
+                    .and_then(|c| Some(c))
                     .ok_or_else(|| ParseUnicodeError::ParseUnicodeFailed { value: u })
             } else {
                 Err(ParseUnicodeError::ParseUnicodeFailed { value: u })


### PR DESCRIPTION
I've been looking into implementing a proper string parser that supports interpretation of escape sequences as mentioned in the CEL [specification](https://github.com/google/cel-spec/blob/master/doc/langdef.md#string-and-bytes-values).

I based my implementation on [snailquote](https://docs.rs/snailquote/latest/snailquote/), but had to change it so that it can support things from CEL specification.

So far it supports all escape sequences and raw strings. I plan to look into supporting triple quotes as well, but in a separate PR.

Please let me know what you think about this approach - maybe you had some different thoughts on how to do this differently, but generally this approach seem to work and could be scaled to other tokens such as byte strings and even numbers.

I'm very new to Rust and would appreciate your feedback. I will look into adding some tests, but need to learn how to do that.