### PR TITLE
Support indexing maps with any valid key type

### DIFF
--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -746,12 +746,12 @@ mod tests {
     #[test]
     fn test_numeric_map_access() {
         let mut context = Context::default();
-        let mut headers = HashMap::new();
-        headers.insert(Key::Uint(0), "zero".to_string());
-        context.add_variable_from_value("headers", headers);
+        let mut numbers = HashMap::new();
+        numbers.insert(Key::Uint(1), "one".to_string());
+        context.add_variable_from_value("numbers", numbers);
 
-        let program = Program::compile("headers[0]").unwrap();
+        let program = Program::compile("numbers[1]").unwrap();
         let value = program.execute(&context).unwrap();
-        assert_eq!(value, "zero".into());
+        assert_eq!(value, "one".into());
     }
 }


### PR DESCRIPTION
According to the spec, maps should support int, uint, and bool keys in addition to strings. The parser already supports this but accessing maps using non-string keys is unimplemented in the interpreter, so I added match cases to support this.

The spec makes it pretty clear that map indexes of ints, uints, and floats are done using the cel's numeric equality (see https://github.com/google/cel-spec/blob/master/doc/langdef.md#equality and https://github.com/google/cel-spec/blob/master/doc/langdef.md#numbers). For statically typed maps this would be rejected by the checker even though its allowed by the runtime, but from what I can tell cel-rust doesn't have a separate check step, so I implemented these to work how spec describes the runtime.