### PR TITLE
Support heterogeneous comparisons for numeric types

### DIFF
--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -160,6 +160,8 @@ impl<'a> Default for Context<'a> {
         ctx.add_function("double", functions::double);
         ctx.add_function("exists", functions::exists);
         ctx.add_function("exists_one", functions::exists_one);
+        ctx.add_function("int", functions::int);
+        ctx.add_function("uint", functions::uint);
         ctx
     }
 }


### PR DESCRIPTION
According to the CEL spec, the CEL runtime supports implicit comparisons of different numerical types: See https://github.com/google/cel-spec/blob/master/doc/langdef.md#equality and https://github.com/google/cel-spec/blob/master/doc/langdef.md#numbers

From what I can tell, cel-rust doesn't have a separate checker step which would reject these implicit comparisons when static types are available, so I just implemented the spec's runtime behavior of always allowing them.

I also added functions to explicitly cast to ints and uints per https://github.com/google/cel-spec/blob/master/doc/langdef.md#list-of-standard-definitions