### PR TITLE
Bump interpreter version to 0.7.1

### DIFF
--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cel-interpreter"
 description = "An interpreter for the Common Expression Language (CEL)"
 repository = "https://github.com/clarkmcc/cel-rust"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Tom Forbes <tom@tomforb.es>", "Clark McCauley <me@clarkmccauley.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
With the merging of #42, I feel like a patch version bump is in order (just the interpreter).
