### PR TITLE
Fix method/fn parsing and lookup

### DIFF
--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -864,7 +864,9 @@ mod tests {
         let program = Program::compile("size(requests) + size == 5").unwrap();
         let mut context = Context::default();
         let requests = vec![Value::Int(42), Value::Int(42)];
-        context.add_variable("requests", Value::List(Arc::new(requests))).unwrap();
+        context
+            .add_variable("requests", Value::List(Arc::new(requests)))
+            .unwrap();
         context.add_variable("size", Value::Int(3)).unwrap();
         assert_eq!(program.execute(&context).unwrap(), Value::Bool(true));
     }

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -520,11 +520,28 @@ impl<'a> Value {
                 })
                 .into()
             }
-            Expression::Ident(name) => {
-                if ctx.has_function(&***name) {
-                    Value::Function(name.clone(), None).into()
+            Expression::Ident(name) => ctx.get_variable(&***name),
+            Expression::FunctionCall(name, target, args) => {
+                if let Expression::Ident(name) = &**name {
+                    let func = ctx.get_function(&**name).unwrap();
+                    match target {
+                        None => {
+                            let mut ctx =
+                                FunctionContext::new(name.clone(), None, ctx, args.clone());
+                            func.call_with_context(&mut ctx)
+                        }
+                        Some(target) => {
+                            let mut ctx = FunctionContext::new(
+                                name.clone(),
+                                Some(Value::resolve(target, ctx)?),
+                                ctx,
+                                args.clone(),
+                            );
+                            func.call_with_context(&mut ctx)
+                        }
+                    }
                 } else {
-                    ctx.get_variable(&***name)
+                    unreachable!("a function name should always be a `Expression::Ident`")
                 }
             }
         }
@@ -592,29 +609,6 @@ impl<'a> Value {
                     (false, false) => NoSuchKey(name.clone()).into(),
                     (true, true) | (true, false) => child.unwrap().into(),
                     (false, true) => Value::Function(name.clone(), Some(self.into())).into(),
-                }
-            }
-            Member::FunctionCall(args) => {
-                if let Value::Function(name, target) = self {
-                    let func = ctx.get_function(&**name).unwrap();
-                    match target {
-                        None => {
-                            let mut ctx =
-                                FunctionContext::new(name.clone(), None, ctx, args.clone());
-                            func.call_with_context(&mut ctx)
-                        }
-                        Some(target) => {
-                            let mut ctx = FunctionContext::new(
-                                name.clone(),
-                                Some(*target),
-                                ctx,
-                                args.clone(),
-                            );
-                            func.call_with_context(&mut ctx)
-                        }
-                    }
-                } else {
-                    unreachable!("FunctionCall without Value::Function - {:?}", self)
                 }
             }
         }
@@ -787,8 +781,9 @@ impl ops::Rem<Value> for Value {
 
 #[cfg(test)]
 mod tests {
-    use crate::{objects::Key, Context, Program};
+    use crate::{objects::Key, Context, Program, Value};
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[test]
     fn test_indexed_map_access() {
@@ -859,8 +854,18 @@ mod tests {
     fn test_invalid_compare() {
         let context = Context::default();
 
-        let program = Program::compile("size == 50").unwrap();
+        let program = Program::compile("{} == []").unwrap();
         let value = program.execute(&context).unwrap();
         assert_eq!(value, false.into());
+    }
+
+    #[test]
+    fn test_size_fn_var() {
+        let program = Program::compile("size(requests) + size == 5").unwrap();
+        let mut context = Context::default();
+        let requests = vec![Value::Int(42), Value::Int(42)];
+        context.add_variable("requests", Value::List(Arc::new(requests))).unwrap();
+        context.add_variable("size", Value::Int(3)).unwrap();
+        assert_eq!(program.execute(&context).unwrap(), Value::Bool(true));
     }
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -39,6 +39,7 @@ pub enum Expression {
     Unary(UnaryOp, Box<Expression>),
 
     Member(Box<Expression>, Box<Member>),
+    FunctionCall(Box<Expression>, Option<Box<Expression>>, Vec<Expression>),
 
     List(Vec<Expression>),
     Map(Vec<(Expression, Expression)>),
@@ -50,7 +51,6 @@ pub enum Expression {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Member {
     Attribute(Arc<String>),
-    FunctionCall(Vec<Expression>),
     Index(Box<Expression>),
     Fields(Vec<(Arc<String>, Expression)>),
 }

--- a/parser/src/cel.lalrpop
+++ b/parser/src/cel.lalrpop
@@ -53,9 +53,8 @@ pub Unary: Expression = {
 pub Member: Expression = {
     <left:Member> "." <identifier:Ident> => Expression::Member(left.into(), Member::Attribute(identifier.into()).into()).into(),
     <left:Member> "." <identifier:Ident> "(" <arguments:CommaSeparated<Expression>> ")" => {
-            let inner = Expression::Member(left.into(), Member::Attribute(identifier.into()).into()).into();
-            Expression::Member(inner, Member::FunctionCall(arguments).into()).into()
-    },
+           Expression::FunctionCall(Expression::Ident(identifier).into(), Some(left.into()), arguments).into()
+   },
     <left:Member> "[" <expression:Expression> "]" => Expression::Member(left.into(), Member::Index(expression.into()).into()).into(),
     <left:Member> "{" <fields:CommaSeparated<FieldInits>> "}" => Expression::Member(left.into(), Member::Fields(fields.into()).into()).into(),
     Primary,
@@ -64,8 +63,7 @@ pub Member: Expression = {
 pub Primary: Expression = {
     "."? <Ident> => Expression::Ident(<>.into()).into(),
     "."? <identifier:Ident> "(" <arguments:CommaSeparated<Expression>> ")" => {
-            let inner = Expression::Ident(identifier.into()).into();
-            Expression::Member(inner, Member::FunctionCall(arguments).into()).into()
+           Expression::FunctionCall(Expression::Ident(identifier).into(), None, arguments).into()
     },
     Atom => Expression::Atom(<>).into(),
     "[" <members:CommaSeparated<Expression>> "]" => Expression::List(<>).into(),

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -142,19 +142,21 @@ mod tests {
     fn test_parse_map_macro() {
         assert_parse_eq(
             "[1, 2, 3].map(x, x * 2)",
-            Member(
-                Box::new(Member(
-                    Box::new(List(vec![Atom(Int(1)), Atom(Int(2)), Atom(Int(3))])),
-                    Box::new(Attribute("map".to_string().into())),
-                )),
-                Box::new(FunctionCall(vec![
+            FunctionCall(
+                Box::new(Ident("map".to_string().into())),
+                Some(Box::new(List(vec![
+                    Atom(Int(1)),
+                    Atom(Int(2)),
+                    Atom(Int(3)),
+                ]))),
+                vec![
                     Ident("x".to_string().into()),
                     Arithmetic(
                         Box::new(Ident("x".to_string().into())),
                         ArithmeticOp::Multiply,
                         Box::new(Atom(Int(2))),
                     ),
-                ])),
+                ],
             ),
         )
     }
@@ -178,10 +180,7 @@ mod tests {
     fn function_call_no_args() {
         assert_parse_eq(
             "a()",
-            Member(
-                Box::new(Ident("a".to_string().into())),
-                Box::new(FunctionCall(vec![])),
-            ),
+            FunctionCall(Box::new(Ident("a".to_string().into())), None, vec![]),
         );
     }
 


### PR DESCRIPTION
Fix #53 

I think this is the AST we discussed, let me know!
Side note: had to change the test that tested for illegal compares, as now `size` looks up a variable _only_. Is this correct? or should an `Ident` be usable to explicitly reference a function? 