### PR TITLE
Only use minimal set of chrono features

### DIFF
--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["compilers"]
 [dependencies]
 cel-parser = { path = "../parser", version = "0.7.0" }
 thiserror = "1.0.40"
-chrono = "0.4.26"
+chrono = { version= "0.4.26", default-features = false, features = ["alloc"] }
 nom = "7.1.3"
 paste = "1.0.14"
 serde = "1.0.196"


### PR DESCRIPTION
Based on what I read, only feature `alloc` of [`chrono`](https://docs.rs/chrono/latest/chrono/#features) is actually required for the interpreter to work (rfc3339 stuff), so I think there is no harm in removing the other cruft…

Fixes #62 