### PR TITLE
Faster bytes parsing

### DIFF
--- a/parser/benches/runtime.rs
+++ b/parser/benches/runtime.rs
@@ -1,7 +1,8 @@
-use cel_parser::parse_string;
+use cel_parser::{parse_bytes, parse_string};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 pub fn parse_string_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("string parsing");
     let expressions = vec![
         ("text", "\"text\""),
         ("raw", "r\"text\""),
@@ -10,10 +11,25 @@ pub fn parse_string_benchmark(c: &mut Criterion) {
         ("single oct escape sequence", "\"\\015\""),
     ];
 
-    for (name, expr) in black_box(&expressions) {
-        c.bench_function(name, |b| b.iter(|| parse_string(expr)));
+    for (name, expr) in black_box(expressions) {
+        group.bench_function(name, |b| b.iter(|| parse_string(expr)));
     }
+    group.finish()
 }
 
-criterion_group!(benches, parse_string_benchmark);
+pub fn parse_bytes_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bytes parsing");
+    let expressions = vec![
+        ("bytes", "text"),
+        ("single hex escape sequence", "x0D"),
+        ("single oct escape sequence", "015"),
+    ];
+
+    for (name, expr) in black_box(expressions) {
+        group.bench_function(name, |b| b.iter(|| parse_bytes(expr)));
+    }
+    group.finish()
+}
+
+criterion_group!(benches, parse_string_benchmark, parse_bytes_benchmark);
 criterion_main!(benches);

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -134,7 +134,10 @@ pub fn parse_bytes(s: &str) -> Result<Vec<u8>, ParseError> {
                 }
             };
         }
-        res.extend(c.to_string().as_bytes());
+        let size = c.len_utf8();
+        let mut buffer = [0; 4];
+        c.encode_utf8(&mut buffer);
+        res.extend_from_slice(&buffer[..size]);
     }
     Ok(res)
 }

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -402,7 +402,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::parse::ParseError;
-    use crate::parse_string;
+    use crate::{parse_bytes, parse_string};
 
     #[test]
     fn single_quotes_interprets_escapes() {
@@ -524,5 +524,11 @@ mod tests {
             let result = parse_string(s);
             assert_eq!(result, expected, "Testing {}", s);
         }
+    }
+
+    #[test]
+    fn parses_bytes() {
+        let bytes = parse_bytes("abc💖\\xFF\\376").expect("Must parse!");
+        assert_eq!([97, 98, 99, 240, 159, 146, 150, 255, 254], *bytes)
     }
 }


### PR DESCRIPTION
Couldn't help it ;) 

Thanks to your feedback [here](https://github.com/clarkmcc/cel-rust/pull/64#discussion_r1676556907), I decided to:

 - [x] Added a bench for parsing bytes
 - [x] Changed the implementation to use a temp buffer

<img width="955" alt="image" src="https://github.com/user-attachments/assets/93d76de6-9f13-423a-96d3-4e9057f8e202">

Also a -21~24% improvements on escaped sequences. Overall better... For us the parsing is less important (and not even x86/arm assembly anyways). But no one ever complained about things being faster. This indeed [saves the vector allocation](https://rust.godbolt.org/z/EE8vP4xTv) due to the `String` conversion. 