### PR TITLE
Convert CEL values to JSON

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,4 +23,6 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
       - name: Run tests
-        run: cargo test --verbose
+        run: |
+          cargo test --verbose
+          cargo test --verbose --features json

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -12,6 +12,7 @@ axum = { version = "0.7.5", default-features = false, features = [
 cel-interpreter = { path = "../interpreter", features = ["json"] }
 chrono = "0.4.26"
 serde = { version = "1.0.196", features = ["derive"] }
+serde_json = "1.0.124"
 thiserror = { version = "1.0.61", default-features = false }
 tokio = { version = "1.38.0", default-features = false, features = [
     "macros",

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,7 +9,7 @@ axum = { version = "0.7.5", default-features = false, features = [
     "json",
     "tokio",
 ] }
-cel-interpreter = { path = "../interpreter" }
+cel-interpreter = { path = "../interpreter", features = ["json"] }
 chrono = "0.4.26"
 serde = { version = "1.0.196", features = ["derive"] }
 thiserror = { version = "1.0.61", default-features = false }
@@ -42,3 +42,8 @@ path = "src/serde.rs"
 [[bin]]
 name = "axum"
 path = "src/axum.rs"
+
+[[bin]]
+name = "json"
+path = "src/json.rs"
+

--- a/example/src/json.rs
+++ b/example/src/json.rs
@@ -1,0 +1,12 @@
+use cel_interpreter::{Context, Program};
+
+fn main() {
+    // Create a CEL program that returns a JSON object
+    let program = Program::compile("{'foo': true}").unwrap();
+    let value = program.execute(&Context::default()).unwrap();
+
+    // Convert the return type to JSON and cast to object
+    let json = value.json().unwrap();
+    let object = json.as_object().unwrap();
+    assert_eq!(Some(&serde_json::Value::Bool(true)), object.get("foo"));
+}

--- a/example/src/serde.rs
+++ b/example/src/serde.rs
@@ -16,8 +16,6 @@ fn main() {
     context
         .add_variable("foo", MyStruct { a: 1, b: 1 })
         .unwrap();
-    // To explicitly serialize structs use to_value()
-    let _cel_value = to_value(MyStruct { a: 2, b: 2 }).unwrap();
 
     let value = program.execute(&context).unwrap();
     assert_eq!(value, true.into());

--- a/example/src/serde.rs
+++ b/example/src/serde.rs
@@ -1,4 +1,4 @@
-use cel_interpreter::{to_value, Context, Program};
+use cel_interpreter::{Context, Program};
 use serde::Serialize;
 
 // An example struct that derives Serialize

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -16,6 +16,8 @@ nom = "7.1.3"
 paste = "1.0.14"
 serde = "1.0.196"
 regex = "1.10.5"
+serde_json = { version = "1.0.124", optional = true }
+base64 = { version = "0.22.1", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -24,3 +26,7 @@ serde_bytes = "0.11.14"
 [[bench]]
 name = "runtime"
 harness = false
+
+[features]
+json = ["dep:base64", "dep:serde_json"]
+

--- a/interpreter/src/json.rs
+++ b/interpreter/src/json.rs
@@ -1,0 +1,103 @@
+use crate::Value;
+use thiserror::Error;
+
+/// Error converting a CEL value to a JSON value.
+#[derive(Debug, Clone, Error)]
+#[error("unable to convert value to json: {0:?}")]
+pub struct ConvertToJsonError<'a>(&'a Value);
+
+impl Value {
+    /// Converts a CEL value to a JSON value.
+    ///
+    /// # Example
+    /// ```
+    /// use cel_interpreter::{Context, Program};
+    ///
+    /// let program = Program::compile("null").unwrap();
+    /// let value = program.execute(&Context::default()).unwrap();
+    /// let result = value.json().unwrap();
+    ///
+    /// assert_eq!(result, serde_json::Value::Null);
+    /// ```
+    pub fn json(&self) -> Result<serde_json::Value, ConvertToJsonError> {
+        use base64::prelude::*;
+        Ok(match *self {
+            Value::List(ref vec) => serde_json::Value::Array(
+                vec.iter()
+                    .map(|v| v.json())
+                    .collect::<Result<Vec<_>, _>>()?,
+            ),
+            Value::Map(ref map) => {
+                let mut obj = serde_json::Map::new();
+                for (k, v) in map.map.iter() {
+                    obj.insert(k.to_string(), v.json()?);
+                }
+                serde_json::Value::Object(obj)
+            }
+            Value::Int(i) => i.into(),
+            Value::UInt(u) => u.into(),
+            Value::Float(f) => f.into(),
+            Value::String(ref s) => s.to_string().into(),
+            Value::Bool(b) => b.into(),
+            Value::Timestamp(ref dt) => dt.to_rfc3339().into(),
+            Value::Bytes(ref b) => BASE64_STANDARD.encode(b.as_slice()).to_string().into(),
+            Value::Null => serde_json::Value::Null,
+            _ => return Err(ConvertToJsonError(self)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Value as CelValue;
+    use serde_json::Value as SerdeValue;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_cel_value_to_json() {
+        let tests = [
+            (
+                SerdeValue::String("hello".to_string()),
+                CelValue::String("hello".to_string().into()),
+            ),
+            (
+                SerdeValue::Number(serde_json::Number::from(42)),
+                CelValue::Int(42),
+            ),
+            (
+                SerdeValue::Number(serde_json::Number::from_f64(42.0).unwrap()),
+                CelValue::Float(42.0),
+            ),
+            (SerdeValue::Bool(true), CelValue::Bool(true)),
+            (SerdeValue::Null, CelValue::Null),
+            (
+                SerdeValue::Array(vec![SerdeValue::Bool(true), SerdeValue::Null]),
+                CelValue::List(vec![CelValue::Bool(true), CelValue::Null].into()),
+            ),
+            (
+                SerdeValue::Object({
+                    let mut obj = serde_json::Map::new();
+                    obj.insert("hello".to_string(), SerdeValue::String("world".to_string()));
+                    obj
+                }),
+                CelValue::Map(
+                    HashMap::from([(
+                        "hello".to_string(),
+                        CelValue::String("world".to_string().into()),
+                    )])
+                        .into(),
+                ),
+            ),
+        ];
+
+        for (expected, value) in tests.iter() {
+            assert_eq!(
+                value.json().unwrap(),
+                *expected,
+                "{:?}={:?}",
+                value,
+                expected
+            );
+        }
+    }
+}

--- a/interpreter/src/json.rs
+++ b/interpreter/src/json.rs
@@ -1,14 +1,18 @@
-use crate::duration::format_duration;
 use crate::Value;
 use chrono::Duration;
 use thiserror::Error;
 
-/// Error converting a CEL value to a JSON value.
 #[derive(Debug, Clone, Error)]
 #[error("unable to convert value to json: {0:?}")]
 pub enum ConvertToJsonError<'a> {
+    /// We cannot convert the CEL value to JSON. Some CEL types (like functions) are
+    /// not representable in JSON.
     #[error("unable to convert value to json: {0:?}")]
     Value(&'a Value),
+
+    /// The duration is too large to convert to nanoseconds. Any duration of 2^63
+    /// nanoseconds or more will overflow. We'll return the duration type in the
+    /// error message.
     #[error("duration too large to convert to nanoseconds: {0:?}")]
     DurationOverflow(&'a Duration),
 }

--- a/interpreter/src/json.rs
+++ b/interpreter/src/json.rs
@@ -1,3 +1,4 @@
+use crate::duration::format_duration;
 use crate::Value;
 use thiserror::Error;
 
@@ -42,6 +43,7 @@ impl Value {
             Value::Timestamp(ref dt) => dt.to_rfc3339().into(),
             Value::Bytes(ref b) => BASE64_STANDARD.encode(b.as_slice()).to_string().into(),
             Value::Null => serde_json::Value::Null,
+            Value::Duration(v) => format_duration(&v).to_string().into(),
             _ => return Err(ConvertToJsonError(self)),
         })
     }
@@ -51,6 +53,7 @@ impl Value {
 mod tests {
     use crate::objects::Map;
     use crate::Value as CelValue;
+    use chrono::Duration;
     use serde_json::json;
     use std::collections::HashMap;
 
@@ -62,6 +65,7 @@ mod tests {
             (json!(42.0), CelValue::Float(42.0)),
             (json!(true), CelValue::Bool(true)),
             (json!(null), CelValue::Null),
+            (json!("1s"), CelValue::Duration(Duration::seconds(1))),
             (
                 json!([true, null]),
                 CelValue::List(vec![CelValue::Bool(true), CelValue::Null].into()),

--- a/interpreter/src/json.rs
+++ b/interpreter/src/json.rs
@@ -51,36 +51,23 @@ impl Value {
 mod tests {
     use crate::objects::Map;
     use crate::Value as CelValue;
-    use serde_json::Value as SerdeValue;
+    use serde_json::json;
     use std::collections::HashMap;
 
     #[test]
     fn test_cel_value_to_json() {
         let tests = [
+            (json!("hello"), CelValue::String("hello".to_string().into())),
+            (json!(42), CelValue::Int(42)),
+            (json!(42.0), CelValue::Float(42.0)),
+            (json!(true), CelValue::Bool(true)),
+            (json!(null), CelValue::Null),
             (
-                SerdeValue::String("hello".to_string()),
-                CelValue::String("hello".to_string().into()),
-            ),
-            (
-                SerdeValue::Number(serde_json::Number::from(42)),
-                CelValue::Int(42),
-            ),
-            (
-                SerdeValue::Number(serde_json::Number::from_f64(42.0).unwrap()),
-                CelValue::Float(42.0),
-            ),
-            (SerdeValue::Bool(true), CelValue::Bool(true)),
-            (SerdeValue::Null, CelValue::Null),
-            (
-                SerdeValue::Array(vec![SerdeValue::Bool(true), SerdeValue::Null]),
+                json!([true, null]),
                 CelValue::List(vec![CelValue::Bool(true), CelValue::Null].into()),
             ),
             (
-                SerdeValue::Object({
-                    let mut obj = serde_json::Map::new();
-                    obj.insert("hello".to_string(), SerdeValue::String("world".to_string()));
-                    obj
-                }),
+                json!({"hello": "world"}),
                 CelValue::Map(Map::from(HashMap::from([(
                     "hello".to_string(),
                     CelValue::String("world".to_string().into()),

--- a/interpreter/src/json.rs
+++ b/interpreter/src/json.rs
@@ -49,6 +49,7 @@ impl Value {
 
 #[cfg(test)]
 mod tests {
+    use crate::objects::Map;
     use crate::Value as CelValue;
     use serde_json::Value as SerdeValue;
     use std::collections::HashMap;
@@ -80,13 +81,10 @@ mod tests {
                     obj.insert("hello".to_string(), SerdeValue::String("world".to_string()));
                     obj
                 }),
-                CelValue::Map(
-                    HashMap::from([(
-                        "hello".to_string(),
-                        CelValue::String("world".to_string().into()),
-                    )])
-                        .into(),
-                ),
+                CelValue::Map(Map::from(HashMap::from([(
+                    "hello".to_string(),
+                    CelValue::String("world".to_string().into()),
+                )]))),
             ),
         ];
 

--- a/interpreter/src/json.rs
+++ b/interpreter/src/json.rs
@@ -1,4 +1,5 @@
 use crate::Value;
+use base64::prelude::*;
 use chrono::Duration;
 use thiserror::Error;
 
@@ -31,7 +32,6 @@ impl Value {
     /// assert_eq!(result, serde_json::Value::Null);
     /// ```
     pub fn json(&self) -> Result<serde_json::Value, ConvertToJsonError> {
-        use base64::prelude::*;
         Ok(match *self {
             Value::List(ref vec) => serde_json::Value::Array(
                 vec.iter()

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -19,8 +19,12 @@ pub mod objects;
 mod resolvers;
 mod ser;
 pub use ser::to_value;
+
+#[cfg(feature = "json")]
+mod json;
 #[cfg(test)]
 mod testing;
+
 use magic::FromContext;
 
 pub mod extractors {

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -100,6 +100,17 @@ impl Serialize for Key {
     }
 }
 
+impl Display for Key {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Key::Int(v) => write!(f, "{}", v),
+            Key::Uint(v) => write!(f, "{}", v),
+            Key::Bool(v) => write!(f, "{}", v),
+            Key::String(v) => write!(f, "{}", v),
+        }
+    }
+}
+
 /// Implement conversions from [`Key`] into [`Value`]
 
 impl TryInto<Key> for Value {
@@ -517,7 +528,7 @@ impl<'a> Value {
                 Value::Map(Map {
                     map: Arc::from(map),
                 })
-                .into()
+                    .into()
             }
             Expression::Ident(name) => ctx.get_variable(&***name),
             Expression::FunctionCall(name, target, args) => {
@@ -573,7 +584,7 @@ impl<'a> Value {
                             None => Value::Null,
                             Some(str) => Value::String(str.to_string().into()),
                         }
-                        .into()
+                            .into()
                     }
                     (Value::Map(map), Value::String(property)) => map
                         .get(&property.into())

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -525,10 +525,9 @@ impl<'a> Value {
                     let value = Value::resolve(v, ctx)?;
                     map.insert(key, value);
                 }
-                Value::Map(Map {
+                Ok(Value::Map(Map {
                     map: Arc::from(map),
-                })
-                    .into()
+                }))
             }
             Expression::Ident(name) => ctx.get_variable(&***name),
             Expression::FunctionCall(name, target, args) => {
@@ -581,10 +580,9 @@ impl<'a> Value {
                         .into(),
                     (Value::String(str), Value::Int(idx)) => {
                         match str.get(idx as usize..(idx + 1) as usize) {
-                            None => Value::Null,
-                            Some(str) => Value::String(str.to_string().into()),
+                            None => Ok(Value::Null),
+                            Some(str) => Ok(Value::String(str.to_string().into())),
                         }
-                            .into()
                     }
                     (Value::Map(map), Value::String(property)) => map
                         .get(&property.into())


### PR DESCRIPTION
This PR adds support for converting CEL values to JSON values.

1. Enable the JSON feature
    ```toml
    cel-interpreter = { ..., features = ["json"] }
    ```
2. Use method on CEL values to convert to JSON
    ```rust
    let value = program.execute(&Context::default()).unwrap();
    let json = value.json().unwrap();