### PR TITLE
Add custom Duration and Timestamp types for conversion with serde

### DIFF
--- a/example/src/serde.rs
+++ b/example/src/serde.rs
@@ -1,4 +1,4 @@
-use cel_interpreter::{Context, Program};
+use cel_interpreter::{Context, Duration, Program, Timestamp};
 use serde::Serialize;
 
 // An example struct that derives Serialize
@@ -6,17 +6,44 @@ use serde::Serialize;
 struct MyStruct {
     a: i32,
     b: i32,
+    // To preserve durations and timestamps, use the cel_interpreter wrapper types.
+    c: Duration,
+    d: Duration,
+    e: Timestamp,
+    f: Timestamp,
 }
 
 fn main() {
-    let program = Program::compile("foo.a == foo.b").unwrap();
     let mut context = Context::default();
 
     // MyStruct will be implicitly serialized into the CEL appropriate types
     context
-        .add_variable("foo", MyStruct { a: 1, b: 1 })
+        .add_variable(
+            "foo",
+            MyStruct {
+                a: 1,
+                b: 1,
+                c: chrono::Duration::hours(2).into(),
+                d: chrono::Duration::hours(2).into(),
+                e: chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")
+                    .unwrap()
+                    .into(),
+                f: chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")
+                    .unwrap()
+                    .into(),
+            },
+        )
         .unwrap();
 
+    let program = Program::compile("foo.a == foo.b").unwrap();
+    let value = program.execute(&context).unwrap();
+    assert_eq!(value, true.into());
+
+    let program = Program::compile("foo.c == foo.d").unwrap();
+    let value = program.execute(&context).unwrap();
+    assert_eq!(value, true.into());
+
+    let program = Program::compile("foo.e == foo.f").unwrap();
     let value = program.execute(&context).unwrap();
     assert_eq!(value, true.into());
 }

--- a/example/src/serde.rs
+++ b/example/src/serde.rs
@@ -1,4 +1,4 @@
-use cel_interpreter::{Context, Duration, Program, Timestamp};
+use cel_interpreter::{Context, Program};
 use serde::Serialize;
 
 // An example struct that derives Serialize
@@ -6,38 +6,17 @@ use serde::Serialize;
 struct MyStruct {
     a: i32,
     b: i32,
-    // To preserve durations and timestamps, use the cel_interpreter wrapper types.
-    c: Duration,
-    d: Timestamp,
 }
 
 fn main() {
+    let program = Program::compile("foo.a == foo.b").unwrap();
     let mut context = Context::default();
 
     // MyStruct will be implicitly serialized into the CEL appropriate types
     context
-        .add_variable(
-            "foo",
-            MyStruct {
-                a: 1,
-                b: 1,
-                c: chrono::Duration::hours(2).into(),
-                d: chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")
-                    .unwrap()
-                    .into(),
-            },
-        )
+        .add_variable("foo", MyStruct { a: 1, b: 1 })
         .unwrap();
 
-    let program = Program::compile("foo.a == foo.b").unwrap();
-    let value = program.execute(&context).unwrap();
-    assert_eq!(value, true.into());
-
-    let program = Program::compile("foo.c == duration('2h')").unwrap();
-    let value = program.execute(&context).unwrap();
-    assert_eq!(value, true.into());
-
-    let program = Program::compile("foo.d == timestamp('1996-12-19T16:39:57-08:00')").unwrap();
     let value = program.execute(&context).unwrap();
     assert_eq!(value, true.into());
 }

--- a/example/src/serde.rs
+++ b/example/src/serde.rs
@@ -8,9 +8,7 @@ struct MyStruct {
     b: i32,
     // To preserve durations and timestamps, use the cel_interpreter wrapper types.
     c: Duration,
-    d: Duration,
-    e: Timestamp,
-    f: Timestamp,
+    d: Timestamp,
 }
 
 fn main() {
@@ -24,11 +22,7 @@ fn main() {
                 a: 1,
                 b: 1,
                 c: chrono::Duration::hours(2).into(),
-                d: chrono::Duration::hours(2).into(),
-                e: chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")
-                    .unwrap()
-                    .into(),
-                f: chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")
+                d: chrono::DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00")
                     .unwrap()
                     .into(),
             },
@@ -39,11 +33,11 @@ fn main() {
     let value = program.execute(&context).unwrap();
     assert_eq!(value, true.into());
 
-    let program = Program::compile("foo.c == foo.d").unwrap();
+    let program = Program::compile("foo.c == duration('2h')").unwrap();
     let value = program.execute(&context).unwrap();
     assert_eq!(value, true.into());
 
-    let program = Program::compile("foo.e == foo.f").unwrap();
+    let program = Program::compile("foo.d == timestamp('1996-12-19T16:39:57-08:00')").unwrap();
     let value = program.execute(&context).unwrap();
     assert_eq!(value, true.into());
 }

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["compilers"]
 [dependencies]
 cel-parser = { path = "../parser", version = "0.7.1 " }
 thiserror = "1.0.40"
-chrono = { version = "0.4.26", default-features = false, features = ["alloc", "serde"] }
+chrono = { version = "0.4.26", default-features = false, features = ["alloc"] }
 nom = "7.1.3"
 paste = "1.0.14"
 serde = "1.0.196"

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["compilers"]
 [dependencies]
 cel-parser = { path = "../parser", version = "0.7.1 " }
 thiserror = "1.0.40"
-chrono = { version = "0.4.26", default-features = false, features = ["alloc"], optional = true }
+chrono = { version = "0.4.26", default-features = false, features = ["alloc", "serde"], optional = true }
 nom = "7.1.3"
 paste = "1.0.14"
 serde = "1.0.196"

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["compilers"]
 [dependencies]
 cel-parser = { path = "../parser", version = "0.7.1 " }
 thiserror = "1.0.40"
-chrono = { version = "0.4.26", default-features = false, features = ["alloc"] }
+chrono = { version = "0.4.26", default-features = false, features = ["alloc", "serde"] }
 nom = "7.1.3"
 paste = "1.0.14"
 serde = "1.0.196"

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -18,7 +18,7 @@ mod magic;
 pub mod objects;
 mod resolvers;
 mod ser;
-pub use ser::to_value;
+pub use ser::{to_value, Duration, Timestamp};
 
 #[cfg(feature = "json")]
 mod json;

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -19,7 +19,9 @@ mod magic;
 pub mod objects;
 mod resolvers;
 mod ser;
-pub use ser::{to_value, Duration, Timestamp};
+pub use ser::to_value;
+#[cfg(feature = "chrono")]
+pub use ser::{Duration, Timestamp};
 
 #[cfg(feature = "json")]
 mod json;

--- a/interpreter/src/ser.rs
+++ b/interpreter/src/ser.rs
@@ -543,13 +543,13 @@ impl ser::SerializeStructVariant for SerializeStructVariant {
 impl ser::SerializeStruct for SerializeTimestamp {
     type Ok = Value;
     type Error = SerializationError;
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T>(
         &mut self,
         key: &'static str,
         value: &T,
     ) -> std::result::Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match key {
             Duration::SECS_FIELD => {

--- a/interpreter/src/ser.rs
+++ b/interpreter/src/ser.rs
@@ -151,7 +151,7 @@ impl ser::Serialize for Timestamp {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_newtype_struct(Self::NAME, &self.0)
+        serializer.serialize_newtype_struct(Self::NAME, &self.0.to_rfc3339())
     }
 }
 

--- a/interpreter/src/ser.rs
+++ b/interpreter/src/ser.rs
@@ -20,6 +20,34 @@ pub struct KeySerializer;
 /// It is only recommended to use this type with the cel_interpreter
 /// [serde::Serializer] implementation, as it may produce unexpected output
 /// with other Serializers.
+///
+/// # Examples
+///
+/// ```
+/// use cel_interpreter::{Context, Duration, Program};
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct MyStruct {
+///     dur: Duration,
+/// }
+///
+/// let mut context = Context::default();
+///
+/// // MyStruct will be implicitly serialized into the CEL appropriate types
+/// context
+///     .add_variable(
+///         "foo",
+///         MyStruct {
+///             dur: chrono::Duration::hours(2).into(),
+///         },
+///     )
+///     .unwrap();
+///
+/// let program = Program::compile("foo.dur == duration('2h')").unwrap();
+/// let value = program.execute(&context).unwrap();
+/// assert_eq!(value, true.into());
+/// ```
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct Duration(pub chrono::Duration);
 
@@ -63,6 +91,36 @@ impl ser::Serialize for Duration {
 /// It is only recommended to use this type with the cel_interpreter
 /// [serde::Serializer] implementation, as it may produce unexpected output
 /// with other Serializers.
+///
+/// # Examples
+///
+/// ```
+/// use cel_interpreter::{Context, Timestamp, Program};
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct MyStruct {
+///     ts: Timestamp,
+/// }
+///
+/// let mut context = Context::default();
+///
+/// // MyStruct will be implicitly serialized into the CEL appropriate types
+/// context
+///     .add_variable(
+///         "foo",
+///         MyStruct {
+///             ts: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+///                 .unwrap()
+///                 .into(),
+///         },
+///     )
+///     .unwrap();
+///
+/// let program = Program::compile("foo.ts == timestamp('2025-01-01T00:00:00Z')").unwrap();
+/// let value = program.execute(&context).unwrap();
+/// assert_eq!(value, true.into());
+/// ```
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 pub struct Timestamp(pub chrono::DateTime<FixedOffset>);
 
@@ -1002,6 +1060,6 @@ mod tests {
             chrono::Duration::nanoseconds(1),
         ]
         .into();
-        assert_eq!(durations, expected)
+        assert_eq!(durations, expected);
     }
 }

--- a/interpreter/src/ser.rs
+++ b/interpreter/src/ser.rs
@@ -986,7 +986,7 @@ mod tests {
     #[test]
     fn test_durations() {
         // Test Duration serialization
-        let map = to_value([
+        let durations = to_value([
             chrono::Duration::milliseconds(1527).into(),
             // Let's test chrono::Duration's particular handling around math
             // and negatives.
@@ -1002,6 +1002,6 @@ mod tests {
             chrono::Duration::nanoseconds(1),
         ]
         .into();
-        assert_eq!(map, expected)
+        assert_eq!(durations, expected)
     }
 }

--- a/interpreter/src/ser.rs
+++ b/interpreter/src/ser.rs
@@ -151,7 +151,7 @@ impl ser::Serialize for Timestamp {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_newtype_struct(Self::NAME, &self.0.to_rfc3339())
+        serializer.serialize_newtype_struct(Self::NAME, &self.0)
     }
 }
 
@@ -789,7 +789,7 @@ impl ser::Serializer for TimeSerializer {
 
     fn serialize_str(self, v: &str) -> Result<Value> {
         assert!(matches!(self, Self::Timestamp));
-        Ok(chrono::DateTime::parse_from_rfc3339(v)
+        Ok(v.parse::<chrono::DateTime<FixedOffset>>()
             .map_err(|e| SerializationError::SerdeError(e.to_string()))?
             .into())
     }

--- a/interpreter/src/ser.rs
+++ b/interpreter/src/ser.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 pub struct Serializer;
 pub struct KeySerializer;
 
-/// A special Duration type which allows conversion to [Value::Duration] for
+/// A wrapper Duration type which allows conversion to [Value::Duration] for
 /// types using automatic conversion with [serde::Serialize].
 ///
 /// It is only recommended to use this type with the cel_interpreter
@@ -57,7 +57,7 @@ impl ser::Serialize for Duration {
     }
 }
 
-/// A special Timestamp type which allows conversion to [Value::Timestamp] for
+/// A wrapper Timestamp type which allows conversion to [Value::Timestamp] for
 /// types using automatic conversion with [serde::Serialize].
 ///
 /// It is only recommended to use this type with the cel_interpreter


### PR DESCRIPTION
Currently `chrono::Duration` doesn't implement `Seralize` and `chrono::DateTime` serializes to an ISO 8601 string. This change is inspired by the [toml crate's approach](https://github.com/toml-rs/toml/blob/b05e8c489be8ebfc0acacc1ec3556d95cd8d2198/crates/toml_datetime/src/datetime.rs#L108) to preserving date formats across functions available in the `Serialize` trait to ensure that durations and timestamp are converted into the appropriate CEL types.

Using the newly exposed `Duration` and `Timestamp` types is only necessary for types using `serde` to convert to CEL, but maybe it could be confusing to keep track of where to use the `chrono` types vs the `cel_interpreter` types? But it seems like an unnecessary breaking change to use the new types in `Value::Duration` and `Value::Timestamp` 🤷🏼 