### PR TITLE
deps: Update lalrpop to 0.22 from 0.19.x

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -9,14 +9,14 @@ license = "MIT"
 categories = ["parsing"]
 
 [dependencies]
-lalrpop-util = { version = "0.19.1", features = ["lexer"] }
+lalrpop-util = { version = "0.22.0", features = ["lexer"] }
 regex = "1.4.2"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [build-dependencies]
-lalrpop = { version = "0.19.1", features = ["lexer"] }
+lalrpop = { version = "0.22.0", features = ["lexer"] }
 
 [[bench]]
 name = "runtime"


### PR DESCRIPTION
Changes can be seen at:

https://github.com/lalrpop/lalrpop/blob/0.22.0/RELEASES.md