### PR TITLE
ci: Update to `actions/checkout@v4`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - name: Format
         run: cargo fmt --all -- --check


### PR DESCRIPTION
This removes a usage within the GitHub Actions of a deprecated version of NodeJS.