### PR TITLE
Fix `clippy::too_long_first_doc_paragraph` lints.

### DIFF
--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -5,15 +5,16 @@ use cel_parser::Expression;
 use std::collections::HashMap;
 
 /// Context is a collection of variables and functions that can be used
-/// by the interpreter to resolve expressions. The context can be either
-/// a parent context, or a child context. A parent context is created by
-/// default and contains all of the built-in functions. A child context
-/// can be created by calling `.clone()`. The child context has it's own
-/// variables (which can be added to), but it will also reference the
-/// parent context. This allows for variables to be overridden within the
-/// child context while still being able to resolve variables in the child's
-/// parents. You can have theoretically have an infinite number of child
-/// contexts that reference each-other.
+/// by the interpreter to resolve expressions.
+///
+/// The context can be either a parent context, or a child context. A
+/// parent context is created by default and contains all of the built-in
+/// functions. A child context can be created by calling `.clone()`. The
+/// child context has it's own variables (which can be added to), but it
+/// will also reference the parent context. This allows for variables to
+/// be overridden within the child context while still being able to
+/// resolve variables in the child's parents. You can have theoretically
+/// have an infinite number of child contexts that reference each-other.
 ///
 /// So why is this important? Well some CEL-macros such as the `.map` macro
 /// declare intermediate user-specified identifiers that should only be

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 type Result<T> = std::result::Result<T, ExecutionError>;
 
 /// `FunctionContext` is a context object passed to functions when they are called.
+///
 /// It contains references to the target object (if the function is called as
 /// a method), the program context ([`Context`]) which gives functions access
 /// to variables, and the arguments to the function call.
@@ -57,8 +58,10 @@ impl<'context> FunctionContext<'context> {
 }
 
 /// Calculates the size of either the target, or the provided args depending on how
-/// the function is called. If called as a method, the target will be used. If called
-/// as a function, the first argument will be used.
+/// the function is called.
+///
+/// If called as a method, the target will be used. If called as a function, the
+/// first argument will be used.
 ///
 /// The following [`Value`] variants are supported:
 /// * [`Value::List`]
@@ -258,10 +261,11 @@ pub fn matches(
     }
 }
 
-/// Returns true if the provided argument can be resolved. This function is
-/// useful for checking if a property exists on a type before attempting to
-/// resolve it. Resolving a property that does not exist will result in a
-/// [`ExecutionError::NoSuchKey`] error.
+/// Returns true if the provided argument can be resolved.
+///
+/// This function is useful for checking if a property exists on a type before
+/// attempting to resolve it. Resolving a property that does not exist will
+/// result in a [`ExecutionError::NoSuchKey`] error.
 ///
 /// Operates similar to the `has` macro describe in the Go CEL implementation
 /// spec: <https://github.com/google/cel-spec/blob/master/doc/langdef.md#macros>.
@@ -284,8 +288,10 @@ pub fn has(ftx: &FunctionContext) -> Result<Value> {
 }
 
 /// Maps the provided list to a new list by applying an expression to each
-/// input item. This function is intended to be used like the CEL-go `map`
-/// macro: <https://github.com/google/cel-spec/blob/master/doc/langdef.md#macros>
+/// input item.
+///
+/// This function is intended to be used like the CEL-go `map` macro:
+/// <https://github.com/google/cel-spec/blob/master/doc/langdef.md#macros>
 ///
 /// # Examples
 /// ```cel
@@ -391,8 +397,9 @@ pub fn all(
 }
 
 /// Returns a boolean value indicating whether a or more values in the provided
-/// list or map meet the predicate defined by the provided expression. If
-/// called on a map, the predicate is applied to the map keys.
+/// list or map meet the predicate defined by the provided expression.
+///
+/// If called on a map, the predicate is applied to the map keys.
 ///
 /// This function is intended to be used like the CEL-go `exists` macro:
 /// <https://github.com/google/cel-spec/blob/master/doc/langdef.md#macros>
@@ -434,8 +441,9 @@ pub fn exists(
 }
 
 /// Returns a boolean value indicating whether only one value in the provided
-/// list or map meets the predicate defined by the provided expression. If
-/// called on a map, the predicate is applied to the map keys.
+/// list or map meets the predicate defined by the provided expression.
+///
+/// If called on a map, the predicate is applied to the map keys.
 ///
 /// This function is intended to be used like the CEL-go `exists` macro:
 /// <https://github.com/google/cel-spec/blob/master/doc/langdef.md#macros>
@@ -486,6 +494,7 @@ pub fn exists_one(
 }
 
 /// Duration parses the provided argument into a [`Value::Duration`] value.
+///
 /// The argument must be string, and must be in the format of a duration. See
 /// the [`parse_duration`] documentation for more information on the supported
 /// formats.

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -75,8 +75,10 @@ pub(crate) trait FromContext<'a, 'context> {
 
 /// A function argument abstraction enabling dynamic method invocation on a
 /// target instance or on the first argument if the function is not called
-/// as a method. This is similar to how methods can be called as functions
-/// using the [fully-qualified syntax](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name).
+/// as a method.
+///
+/// This is similar to how methods can be called as functions using the
+/// [fully-qualified syntax](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name).
 ///
 /// # Using `This`
 /// ```
@@ -142,8 +144,10 @@ where
 }
 
 /// Identifier is an argument extractor that attempts to extract an identifier
-/// from an argument's expression. It fails if the argument is not available,
-/// or if the argument cannot be converted into an expression.
+/// from an argument's expression.
+///
+/// It fails if the argument is not available, or if the argument cannot be
+/// converted into an expression.
 ///
 /// # Examples
 /// Identifiers are useful for functions like `.map` or `.filter` where one
@@ -198,9 +202,10 @@ impl From<Identifier> for String {
 }
 
 /// An argument extractor that extracts all the arguments passed to a function, resolves their
-/// expressions and returns a vector of [`Value`]. This is useful for functions that accept a
-/// variable number of arguments rather than known arguments and types (for example a `sum`
-/// function).
+/// expressions and returns a vector of [`Value`].
+///
+/// This is useful for functions that accept a variable number of arguments rather than known
+/// arguments and types (for example a `sum` function).
 ///
 /// # Example
 /// ```javascript


### PR DESCRIPTION
These are new in Rust 1.82 which is due to be released shortly.