### PR TITLE
Added missing timestamp macros

### DIFF
--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -185,10 +185,21 @@ impl<'a> Default for Context<'a> {
 
         #[cfg(feature = "regex")]
         ctx.add_function("matches", functions::matches);
-        #[cfg(feature = "chrono")]
-        ctx.add_function("duration", functions::duration);
-        #[cfg(feature = "chrono")]
-        ctx.add_function("timestamp", functions::timestamp);
+
+        if cfg!(feature = "chrono") {
+            ctx.add_function("duration", functions::time::duration);
+            ctx.add_function("timestamp", functions::time::timestamp);
+            ctx.add_function("getFullYear", functions::time::timestamp_year);
+            ctx.add_function("getMonth", functions::time::timestamp_month);
+            ctx.add_function("getDayOfYear", functions::time::timestamp_year_day);
+            ctx.add_function("getDayOfMonth", functions::time::timestamp_month_day);
+            ctx.add_function("getDate", functions::time::timestamp_date);
+            ctx.add_function("getDayOfWeek", functions::time::timestamp_weekday);
+            ctx.add_function("getHours", functions::time::timestamp_hours);
+            ctx.add_function("getMinutes", functions::time::timestamp_minutes);
+            ctx.add_function("getSeconds", functions::time::timestamp_seconds);
+            ctx.add_function("getMilliseconds", functions::time::timestamp_millis);
+        }
 
         ctx
     }


### PR DESCRIPTION
This adds support for [these built-ins macros](https://github.com/clarkmcc/cel-rust/pull/106/files#diff-5bcb7f8139c1eb333eae115bb7678386b792529078626aabfd4eeec5b872f7e0R809-R846) on `Timestamp`

I moved things around a bit, given the explosion of repetition with the `feature = "chrono"`, but let me know if you want to rearrange this differently 🙏  