### PR TITLE
Fix compilation without chrono

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Format
         run: cargo fmt --all -- --check
-      - name: Build
+      - name: Build minimal
+        run: cargo build --no-default-features --verbose
+      - name: Build with all features
         run: cargo build --verbose
       - name: Clippy
         run: cargo clippy --all-features --all-targets -- -D warnings

--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -186,7 +186,8 @@ impl<'a> Default for Context<'a> {
         #[cfg(feature = "regex")]
         ctx.add_function("matches", functions::matches);
 
-        if cfg!(feature = "chrono") {
+        #[cfg(feature = "chrono")]
+        {
             ctx.add_function("duration", functions::time::duration);
             ctx.add_function("timestamp", functions::time::timestamp);
             ctx.add_function("getFullYear", functions::time::timestamp_year);


### PR DESCRIPTION
This PR fixes compilation without chrono

Previously `cfg!(feature = "chrono")` was used which blocks execution at runtime, this was switched out with a `#[cfg(feature = "chrono")]` block which will block the code at compile time. Blocking it at runtime doesn't work because prevented functions in `functions::time` don't exist so this causes a compile error.

Added a minimal build to the CI to avoid these kinds of problems in future.