### PR TITLE
ValueType copy & debug

### DIFF
--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -174,6 +174,7 @@ pub enum Value {
     Null,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum ValueType {
     List,
     Map,


### PR DESCRIPTION
When using the `ValueType` type currently, things can get [slightly more complex](https://github.com/Kuadrant/wasm-shim/blob/main/src/data/cel.rs#L311-L326) than really needed I think. 
I don't see a reason why it wouldn't implement both `Debug` & `Copy` trait… wdyt?