### PR TITLE
Expose Serialization and ConvertToJson errors

### DIFF
--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -23,9 +23,12 @@ mod duration;
 
 mod ser;
 pub use ser::to_value;
+pub use ser::SerializationError;
 
 #[cfg(feature = "json")]
 mod json;
+#[cfg(feature = "json")]
+pub use json::ConvertToJsonError;
 
 use magic::FromContext;
 


### PR DESCRIPTION
The errors are public but since the `ser` and `json` modules are private they're not usable outside of the interpreter