### PR TITLE
feat: Implement Short-Circuit Evaluation for AND Expressions to Fix Issue #117

### DIFF
--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -40,7 +40,7 @@ pub enum Context<'a> {
     },
 }
 
-impl<'a> Context<'a> {
+impl Context<'_> {
     pub fn add_variable<S, V>(
         &mut self,
         name: S,
@@ -159,7 +159,7 @@ impl<'a> Context<'a> {
     }
 }
 
-impl<'a> Default for Context<'a> {
+impl Default for Context<'_> {
     fn default() -> Self {
         let mut ctx = Context::Root {
             variables: Default::default(),

--- a/interpreter/src/functions.rs
+++ b/interpreter/src/functions.rs
@@ -381,7 +381,7 @@ pub fn all(
     ident: Identifier,
     expr: Expression,
 ) -> Result<bool> {
-    return match this {
+    match this {
         Value::List(items) => {
             let mut ptx = ftx.ptx.new_inner_scope();
             for item in items.iter() {
@@ -402,8 +402,8 @@ pub fn all(
             }
             Ok(true)
         }
-        _ => return Err(this.error_expected_type(ValueType::List)),
-    };
+        _ => Err(this.error_expected_type(ValueType::List)),
+    }
 }
 
 /// Returns a boolean value indicating whether a or more values in the provided

--- a/interpreter/src/magic.rs
+++ b/interpreter/src/magic.rs
@@ -230,7 +230,7 @@ impl From<Identifier> for String {
 #[derive(Clone)]
 pub struct Arguments(pub Arc<Vec<Value>>);
 
-impl<'a, 'context> FromContext<'a, 'context> for Arguments {
+impl<'a> FromContext<'a, '_> for Arguments {
     fn from_context(ctx: &'a mut FunctionContext) -> Result<Self, ExecutionError>
     where
         Self: Sized,
@@ -389,7 +389,7 @@ impl<'a, 'context, H, T> HandlerCallable<'a, 'context, H, T> {
     }
 }
 
-impl<'a, 'context, H, T> Callable for HandlerCallable<'a, 'context, H, T>
+impl<H, T> Callable for HandlerCallable<'_, '_, H, T>
 where
     H: Handler<T> + Clone + 'static,
 {

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -987,7 +987,7 @@ mod tests {
         let program = Program::compile("has(data.x) && data.x.startsWith(\"foo\")").unwrap();
         let value = program.execute(&context);
         assert!(
-            value.is_ok(), 
+            value.is_ok(),
             "The AND expression should support short-circuit evaluation."
         );
     }

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -487,10 +487,10 @@ impl<'a> Value {
             Expression::And(left, right) => {
                 let left = Value::resolve(left, ctx)?;
                 if !left.to_bool() {
-                    left.into()
+                    Value::Bool(false).into()
                 } else {
                     let right = Value::resolve(right, ctx)?;
-                    right.into()
+                    Value::Bool(right.to_bool()).into()
                 }
             }
             Expression::Unary(op, expr) => {

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -981,11 +981,14 @@ mod tests {
     #[test]
     fn test_short_curcuit_and() {
         let mut context = Context::default();
-        let data: HashMap<String, String>  = HashMap::new();
+        let data: HashMap<String, String> = HashMap::new();
         context.add_variable_from_value("data", data);
 
         let program = Program::compile("has(data.x) && data.x.startsWith(\"foo\")").unwrap();
         let value = program.execute(&context);
-        assert!(value.is_ok(), "The AND expression should support short-circuit evaluation.");
+        assert!(
+            value.is_ok(), 
+            "The AND expression should support short-circuit evaluation."
+        );
     }
 }

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -405,7 +405,7 @@ impl From<Value> for ResolveResult {
     }
 }
 
-impl<'a> Value {
+impl Value {
     pub fn resolve_all(expr: &[Expression], ctx: &Context) -> ResolveResult {
         let mut res = Vec::with_capacity(expr.len());
         for expr in expr {
@@ -415,7 +415,7 @@ impl<'a> Value {
     }
 
     #[inline(always)]
-    pub fn resolve(expr: &'a Expression, ctx: &Context) -> ResolveResult {
+    pub fn resolve(expr: &Expression, ctx: &Context) -> ResolveResult {
         match expr {
             Expression::Atom(atom) => Ok(atom.into()),
             Expression::Arithmetic(left, op, right) => {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -73,7 +73,7 @@ pub struct ExpressionReferences<'expr> {
     functions: HashSet<&'expr str>,
 }
 
-impl<'expr> ExpressionReferences<'expr> {
+impl ExpressionReferences<'_> {
     /// Returns true if the expression references the provided variable name.
     ///
     /// # Example


### PR DESCRIPTION
Summary
This pull request implements short-circuit evaluation for AND expressions in the program compiler, enhancing the language's functionality and preventing unnecessary errors.



Related Issue
Fixes #117