### PR TITLE
fix: improve `Context::add_variable` `Err` type

### DIFF
--- a/interpreter/src/context.rs
+++ b/interpreter/src/context.rs
@@ -45,7 +45,7 @@ impl Context<'_> {
         &mut self,
         name: S,
         value: V,
-    ) -> Result<(), Box<dyn std::error::Error>>
+    ) -> Result<(), <V as TryIntoValue>::Error>
     where
         S: Into<String>,
         V: TryIntoValue,

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -136,7 +136,7 @@ impl<K: Into<Key>, V: Into<Value>> From<HashMap<K, V>> for Map {
 }
 
 pub trait TryIntoValue {
-    type Error: std::error::Error + 'static;
+    type Error: std::error::Error + 'static + Send + Sync;
     fn try_into_value(self) -> Result<Value, Self::Error>;
 }
 


### PR DESCRIPTION
Closes #126 

Improve the bounds of `TryIntoValue::Error` and the return type of `Context::add_variable`.

The bounds changes make the error more convenient to use with `anyhow`.