### PR TITLE
Optional support... in the parser

### DIFF
--- a/antlr/src/ast/mod.rs
+++ b/antlr/src/ast/mod.rs
@@ -84,6 +84,13 @@ pub struct MapExpr {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct ListExpr {
     pub elements: Vec<IdedExpr>,
+    pub opt_indices: Vec<usize>,
+}
+
+impl ListExpr {
+    pub fn id_optional(&self, index: usize) -> bool {
+        self.opt_indices.contains(&index)
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/antlr/src/macros.rs
+++ b/antlr/src/macros.rs
@@ -225,7 +225,10 @@ fn map_macro_expander(
     let func = args.pop().unwrap();
     let v = extract_ident(args.remove(0), helper)?;
 
-    let init = helper.next_expr(Expr::List(ListExpr { elements: vec![] }));
+    let init = helper.next_expr(Expr::List(ListExpr {
+        elements: vec![],
+        opt_indices: vec![],
+    }));
     let result_binding = "@result".to_string();
     let condition = helper.next_expr(Expr::Literal(Boolean(true)));
 
@@ -235,6 +238,7 @@ fn map_macro_expander(
         helper.next_expr(Expr::Ident(result_binding.clone())),
         helper.next_expr(Expr::List(ListExpr {
             elements: vec![func],
+            opt_indices: vec![],
         })),
     ];
     let step = helper.next_expr(Expr::Call(CallExpr {
@@ -285,7 +289,10 @@ fn filter_macro_expander(
     let v = extract_ident(var.clone(), helper)?;
     let filter = args.pop().unwrap();
 
-    let init = helper.next_expr(Expr::List(ListExpr { elements: vec![] }));
+    let init = helper.next_expr(Expr::List(ListExpr {
+        elements: vec![],
+        opt_indices: vec![],
+    }));
     let result_binding = "@result".to_string();
     let condition = helper.next_expr(Expr::Literal(Boolean(true)));
 
@@ -293,6 +300,7 @@ fn filter_macro_expander(
         helper.next_expr(Expr::Ident(result_binding.clone())),
         helper.next_expr(Expr::List(ListExpr {
             elements: vec![var],
+            opt_indices: vec![],
         })),
     ];
     let step = helper.next_expr(Expr::Call(CallExpr {


### PR DESCRIPTION
These few commits add support for the optional syntax (`?`) in the parser and AST nodes. Now, as it turns out, the golang implementation has [a `type Optional struct`](https://github.com/google/cel-go/blob/d45f67fee20b8ecd7eacf1747bd60e0d8f4c4835/common/types/optional.go#L39-L41), which [implements `type Val interface`](https://github.com/google/cel-go/blob/d651ee2942929d1d00c5332c810bd1e1539bcc86/common/types/ref/reference.go#L37-L63)... 

So I can either "hack" that in the current interpreter (i.e. probably short-circuit interpretation, and "early" return `Null`), or... I guess it's what I'd recommend anyways, I start revisiting the whole type system. Which also leads me to bunch of questions. Including the need for `Value` to own "thread safe" values... I never really got why this is dealt with at that level in the "graph". As a CEL expression is to be immutable (modulo some cases e.g. the accumulator in macros), and even if an expression is to be shared across thread for concurrent execution, wouldn't it be the `Context` that should be thread safe, and can't we consider the expression as immutable, possibly the expression being reference counted?

Anyways, I guess I'm opening quite a can of worms here. But I think I'd be tempted to start exploring revisiting the type system, leave thread-safety aside, if only for now. There, my first question becomes: should we go for `dyn`amic dispatch (i.e. have a it all model with traits) or would it be nice to keep things as concrete as possible? I feel the go implementation has a bit of "interface derangement syndrome",  but it might also all be for a good reason... 