### PR TITLE
fix: Do not expose internal comprehension var idents

### DIFF
--- a/antlr/src/references.rs
+++ b/antlr/src/references.rs
@@ -110,7 +110,10 @@ impl IdedExpr {
                 comp.result._references(variables, functions);
             }
             Expr::Ident(name) => {
-                variables.insert(name);
+                // todo! Might want to make this "smarter" (are we in a comprehension?) and better encode these in const
+                if !name.starts_with('@') {
+                    variables.insert(name);
+                }
             }
             Expr::List(list) => {
                 for elem in &list.elements {

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -237,6 +237,13 @@ mod tests {
     }
 
     #[test]
+    fn references() {
+        let p = Program::compile("[1, 1].map(x, x * 2)").unwrap();
+        assert!(p.references().has_variable("x"));
+        assert_eq!(p.references().variables().len(), 1);
+    }
+
+    #[test]
     fn test_execution_errors() {
         let tests = vec![
             (


### PR DESCRIPTION
`Comprehension` nodes in the AST are the result of macro expansions. These do declare "internal" bindings, prefixed with `@`, which would otherwise be invalid `Ident`s according to the grammar (i.e. a use can't declare an `Ident` starting with `@` in unparsed CEL expression).

But `Expression::expressions` would have exposed the binding and make it visible. I don't think we want that... if anything this aligns the behavior with how the interpreter worked until the new antlr parser and the new AST.