### PR TITLE
Remove redundant string/error allocations/clones during name resolution

### DIFF
--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -55,7 +55,7 @@ impl From<String> for Key {
 
 impl From<Arc<String>> for Key {
     fn from(v: Arc<String>) -> Self {
-        Key::String(v.clone())
+        Key::String(v)
     }
 }
 

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -713,7 +713,11 @@ impl Value {
     //               Attribute("b")),
     //        FunctionCall([Ident("c")]))
 
-    fn member(self, name: &String, ctx: &Context) -> ResolveResult {
+    fn member(self, name: &str, ctx: &Context) -> ResolveResult {
+        // todo! Ideally we would avoid creating a String just to create a Key for lookup in the
+        // map, but this would require something like the `hashbrown` crate's `Equivalent` trait.
+        let name: Arc<String> = name.to_owned().into();
+
         // This will always either be because we're trying to access
         // a property on self, or a method on self.
         let child = match self {
@@ -724,10 +728,10 @@ impl Value {
         // If the property is both an attribute and a method, then we
         // give priority to the property. Maybe we can implement lookahead
         // to see if the next token is a function call?
-        match (child, ctx.has_function(name)) {
-            (None, false) => ExecutionError::NoSuchKey(name.clone().into()).into(),
+        match (child, ctx.has_function(&name)) {
+            (None, false) => ExecutionError::NoSuchKey(name).into(),
             (Some(child), _) => child.into(),
-            (None, true) => Value::Function(name.clone().into(), Some(self.into())).into(),
+            (None, true) => Value::Function(name, Some(self.into())).into(),
         }
     }
 


### PR DESCRIPTION
Previously `get_variable` discarded the recursive call's result, and the crate-only `get_function`, `has_function`, and `member` methods created some unnecessary `String`s.

We could also replace `get_variable` of the `Into<String>` parameter with `&str`, but this affects the public API, so I've held off for now.