### PR TITLE
Avoid panics due to division by zero and integer overflow

### DIFF
--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -95,6 +95,12 @@ pub enum ExecutionError {
     /// Indicates that a function had an error during execution.
     #[error("Error executing function '{function}': {message}")]
     FunctionError { function: String, message: String },
+    #[error("Division by zero of {0:?}")]
+    DivisionByZero(Value),
+    #[error("Remainder by zero of {0:?}")]
+    RemainderByZero(Value),
+    #[error("Integer overflow from binary operator '{0}': {1:?}, {2:?}")]
+    IntegerOverflow(&'static str, Value, Value),
 }
 
 impl ExecutionError {


### PR DESCRIPTION
By returning an error instead, which also brings this crate further into conformance with the other CEL implementations.

https://github.com/google/cel-spec/blob/master/doc/langdef.md#overflow
https://github.com/google/cel-spec/blob/master/tests/simple/testdata/integer_math.textproto

Feel free to suggest an alternative design for the new `ExecutionError` variants.