### PR TITLE
Append to lists and strings in place instead of cloning when possible

### DIFF
--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -779,14 +779,27 @@ impl ops::Add<Value> for Value {
             (Value::UInt(l), Value::Float(r)) => Value::Float(l as f64 + r).into(),
             (Value::Float(l), Value::UInt(r)) => Value::Float(l + r as f64).into(),
 
-            (Value::List(l), Value::List(r)) => {
-                Value::List(l.iter().chain(r.iter()).cloned().collect::<Vec<_>>().into()).into()
+            (Value::List(mut l), Value::List(mut r)) => {
+                {
+                    // If this is the only reference to `l`, we can append to it in place.
+                    // `l` is replaced with a clone otherwise.
+                    let l = Arc::make_mut(&mut l);
+
+                    // Likewise, if this is the only reference to `r`, we can move its values
+                    // instead of cloning them.
+                    match Arc::get_mut(&mut r) {
+                        Some(r) => l.append(r),
+                        None => l.extend(r.iter().cloned()),
+                    }
+                }
+
+                Ok(Value::List(l))
             }
-            (Value::String(l), Value::String(r)) => {
-                let mut new = String::with_capacity(l.len() + r.len());
-                new.push_str(&l);
-                new.push_str(&r);
-                Value::String(new.into()).into()
+            (Value::String(mut l), Value::String(r)) => {
+                // If this is the only reference to `l`, we can append to it in place.
+                // `l` is replaced with a clone otherwise.
+                Arc::make_mut(&mut l).push_str(&r);
+                Ok(Value::String(l))
             }
             // Merge two maps should overwrite keys in the left map with the right map
             (Value::Map(l), Value::Map(r)) => {


### PR DESCRIPTION
As long as lists and strings are used behind an Arc, the left-hand list can be modified in place when no other reference to it exists.

Additionally, when the same condition applies to the right-hand list, its items can be moved into the left-hand list, rather than cloned.

Together, this can make expressions like `[...] + [...] + [...]` more efficient.

According to `cargo bench` locally:

```
add_list        time:   [180.38 ns 180.58 ns 180.84 ns]
                change: [-16.091% -15.608% -15.162%] (p = 0.00 < 0.05)
                Performance has improved.

add_string      time:   [75.361 ns 75.448 ns 75.535 ns]
                change: [-13.354% -12.974% -12.661%] (p = 0.00 < 0.05)
                Performance has improved.
```

Of course, in both of these benches, both operands are uniquely referenced, and there is only a single thread. That said, from Arc's own documentation (https://doc.rust-lang.org/std/sync/struct.Arc.html):

> Use clone-on-write semantics with Arc::make_mut which provides
efficient mutation without requiring interior mutability. This approach clones the data only when needed (when there are multiple references) and can be more efficient when mutations are infrequent.

This change cannot cause values contained in a Context to be modified by construction: The Context itself retains a strong reference, meaning that the values received by `Add::add` cannot be unique.