### PR TITLE
Add basic infrastructure for fuzzing and one target for Value binops

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["antlr", "interpreter", "example"]
+members = ["antlr", "interpreter", "example", "fuzz"]
 resolver = "2"
 
 [profile.bench]

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "cel-parser-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+arbitrary = { version = "1.4.1", features = ["derive"] }
+libfuzzer-sys = "0.4"
+
+[dependencies.cel-interpreter]
+path = "../interpreter"
+features = ["arbitrary"]
+
+[[bin]]
+name = "value_binop"
+path = "fuzz_targets/value_binop.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/value_binop.rs
+++ b/fuzz/fuzz_targets/value_binop.rs
@@ -1,0 +1,37 @@
+#![no_main]
+
+use cel_interpreter::Value;
+use libfuzzer_sys::fuzz_target;
+use std::hint::black_box;
+
+#[derive(Debug, arbitrary::Arbitrary)]
+enum BinOp {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem,
+    Eq,
+    Cmp,
+}
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct Input {
+    op: BinOp,
+    lhs: Value,
+    rhs: Value,
+}
+
+// Ensure that the binary operators on `Value` do not panic,
+// c.f. https://github.com/clarkmcc/cel-rust/pull/145.
+fuzz_target!(|input: Input| {
+    match input.op {
+        BinOp::Add => _ = black_box(input.lhs + input.rhs),
+        BinOp::Sub => _ = black_box(input.lhs - input.rhs),
+        BinOp::Mul => _ = black_box(input.lhs * input.rhs),
+        BinOp::Div => _ = black_box(input.lhs / input.rhs),
+        BinOp::Rem => _ = black_box(input.lhs % input.rhs),
+        BinOp::Eq => _ = black_box(input.lhs == input.rhs),
+        BinOp::Cmp => _ = black_box(input.lhs.partial_cmp(&input.rhs)),
+    }
+});

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -21,6 +21,7 @@ base64 = { version = "0.22.1", optional = true }
 
 thiserror = "1.0"
 paste = "1.0"
+arbitrary = { version = "1.4.1", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
@@ -35,3 +36,4 @@ default = ["regex", "chrono"]
 json = ["dep:serde_json", "dep:base64"]
 regex = ["dep:regex"]
 chrono = ["dep:chrono"]
+arbitrary = ["dep:arbitrary", "chrono?/arbitrary", "chrono?/std"]

--- a/interpreter/src/objects.rs
+++ b/interpreter/src/objects.rs
@@ -12,6 +12,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Map {
     pub map: Arc<HashMap<Key, Value>>,
 }
@@ -39,6 +40,7 @@ impl Map {
 }
 
 #[derive(Debug, Eq, PartialEq, Hash, Ord, Clone, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Key {
     Int(i64),
     Uint(u64),
@@ -156,6 +158,7 @@ impl TryIntoValue for Value {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Value {
     List(Arc<Vec<Value>>),
     Map(Map),


### PR DESCRIPTION
Fuzzing should occur on a number of levels, given that this project will frequently be used to run programs compiled from potentially untrusted inputs, most importantly parsing and expression evaluation.

We start by adding a simple fuzz target for Value's binary operator trait implementations, since those were already manually found to panic under certain conditions in #145.

To facilitate fuzzing of structured types, including Value, we add an optional dependency on the arbitrary crate. See
https://rust-fuzz.github.io/book/cargo-fuzz/structure-aware-fuzzing.html for details.

Running this requires nightly Rust:

```
cargo +nightly fuzz run value_binop
```