### PR TITLE
Address warnings in non-default configurations

### DIFF
--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -9,7 +9,9 @@ use std::convert::{Infallible, TryFrom, TryInto};
 use std::fmt::{Display, Formatter};
 use std::ops;
 use std::ops::Deref;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
+#[cfg(feature = "chrono")]
+use std::sync::LazyLock;
 
 #[cfg(feature = "chrono")]
 use chrono::TimeZone;
@@ -971,11 +973,14 @@ impl ops::Rem<Value> for Value {
 }
 
 /// Op represents a binary arithmetic operation supported on a timestamp
+///
+#[cfg(feature = "chrono")]
 enum TsOp {
     Add,
     Sub,
 }
 
+#[cfg(feature = "chrono")]
 impl TsOp {
     fn str(&self) -> &'static str {
         match self {

--- a/cel/src/ser.rs
+++ b/cel/src/ser.rs
@@ -5,7 +5,7 @@
 
 use crate::{objects::Key, Value};
 use serde::{
-    ser::{self, Impossible, SerializeStruct},
+    ser::{self, Impossible},
     Serialize,
 };
 use std::{collections::HashMap, fmt::Display, iter::FromIterator, sync::Arc};
@@ -13,6 +13,8 @@ use thiserror::Error;
 
 #[cfg(feature = "chrono")]
 use chrono::FixedOffset;
+#[cfg(feature = "chrono")]
+use serde::ser::SerializeStruct;
 
 pub struct Serializer;
 pub struct KeySerializer;


### PR DESCRIPTION
When using cel-rust with a local path and no default features, a few warnings about unused usings and dead code appear in rust-analyzer.

These don't appear when using cel-rust from e.g. crates.io, since it treats those as out of scope apparently (which, well, if it didn't, would be very noisy).

Since they're trivial to address with a few more cfg macros, address them.