### PR TITLE
Avoid cloning key on hotpath

### DIFF
--- a/cel/src/common/ast/mod.rs
+++ b/cel/src/common/ast/mod.rs
@@ -1,5 +1,6 @@
 use crate::common::value::CelVal;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 pub mod operators;
 
@@ -66,7 +67,7 @@ pub struct CallExpr {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct SelectExpr {
     pub operand: Box<IdedExpr>,
-    pub field: String,
+    pub field: Arc<String>,
     pub test: bool,
 }
 

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -701,8 +701,10 @@ impl Value {
                     match &left {
                         Value::Map(map) => {
                             for key in map.map.deref().keys() {
-                                if key.to_string().eq(&select.field) {
-                                    return Ok(Value::Bool(true));
+                                if let Key::String(k) = key {
+                                    if k == &select.field {
+                                        return Ok(Value::Bool(true));
+                                    }
                                 }
                             }
                             Ok(Value::Bool(false))
@@ -791,7 +793,7 @@ impl Value {
         // This will always either be because we're trying to access
         // a property on self, or a method on self.
         let child = match self {
-            Value::Map(ref m) => m.map.get(&name.clone().into()).cloned(),
+            Value::Map(ref m) => m.map.get(&Key::String(name.clone())),
             _ => None,
         };
 
@@ -799,7 +801,7 @@ impl Value {
         // give priority to the property. Maybe we can implement lookahead
         // to see if the next token is a function call?
         if let Some(child) = child {
-            child.into()
+            child.clone().into()
         } else {
             ExecutionError::NoSuchKey(name.clone()).into()
         }

--- a/cel/src/parser/parser.rs
+++ b/cel/src/parser/parser.rs
@@ -728,7 +728,7 @@ impl gen::CELVisitorCompat<'_> for Parser {
                 op.as_ref(),
                 Expr::Select(SelectExpr {
                     operand: Box::new(operand),
-                    field,
+                    field: Arc::new(field),
                     test: false,
                 }),
             )


### PR DESCRIPTION
```
                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
                     │               │               │               │         │
      ╰─ old           75.1 ns       │ 87.45 ns      │ 77.06 ns      │ 77.48 ns      │ 100     │ 1000000
      ╰─ new           59.7 ns       │ 74.89 ns      │ 60.89 ns      │ 61.55 ns      │ 100     │ 1000000
```

This is a breaking change to SelectExpr but a minor one. The `member` function is private.