### PR TITLE
chores: updated antlr4rust to v0.3.0-rc1 explicitly

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 categories = ["compilers"]
 
 [dependencies]
-antlr4rust = "0.3.0-beta3"
+antlr4rust = "0.3.0-rc1"
 lazy_static = "1.5.0"
 nom = "7.1.3"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "serde"], optional = true }


### PR DESCRIPTION
With [antlr4rust v0.3.0-rc1](https://crates.io/crates/antlr4rust/0.3.0-rc1) released, #188 should be resolved for everyone.