### PR TITLE
Explicit declare minimum Rust version

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Clark McCauley <me@clarkmccauley.com>", "Alex Snaps <alex@wcgw.dev>"
 edition = "2021"
 license = "MIT"
 categories = ["compilers"]
+rust-version = "1.87"
 
 [dependencies]
 antlr4rust = "0.3.0-rc2"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.87.0"


### PR DESCRIPTION
This crate does not compile on Rust 1.86 or earlier, so make this explicit.