### PR TITLE
feat(parser): Proper support for comments

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 categories = ["compilers"]
 
 [dependencies]
-antlr4rust = "0.5.1"
+antlr4rust = "0.5.2"
 lazy_static = "1.5.0"
 nom = "7.1.3"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "serde"], optional = true }

--- a/cel/src/parser/parser.rs
+++ b/cel/src/parser/parser.rs
@@ -188,7 +188,6 @@ impl Parser {
     }
 
     pub fn parse(mut self, source: &str) -> Result<IdedExpr, ParseErrors> {
-        let source = source.trim();
         let parse_errors = Rc::new(RefCell::new(Vec::<ParseError>::new()));
         let stream = InputStream::new(source);
         let mut lexer = gen::CELLexer::new(stream);
@@ -1150,6 +1149,18 @@ mod tests {
                 expr
             );
         }
+    }
+
+    #[test]
+    fn test_comments() {
+        let expression = r#"
+        // This is a comment
+        this.is.not()
+
+        // We don't care!
+
+        "#;
+        assert!(Parser::new().parse(expression).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
including at the beginning of an expression. No need to `String::trim` neither anymore... Makes for nicer error reporting as well