### PR TITLE
initial expression optimizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,4 @@ lto = true
 codegen-units = 1
 opt-level = 3
 # Line numbers for dhat
-debug = 1
+debug = true

--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1.0"
 paste = "1.0"
 
 [dev-dependencies]
+pprof = { version = "0.15", features = ["protobuf", "protobuf-codec", "criterion"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 serde_bytes = "0.11.14"
 dhat = { version = "0.3.3" }

--- a/cel/src/common/ast/mod.rs
+++ b/cel/src/common/ast/mod.rs
@@ -1,4 +1,5 @@
 use crate::common::value::CelVal;
+use crate::Value;
 use std::collections::BTreeMap;
 
 pub mod operators;
@@ -27,6 +28,9 @@ pub enum Expr {
 
     /// LiteralKind represents a primitive scalar literal.
     Literal(CelVal),
+
+    /// An inlined Value
+    Inline(Value),
 
     /// MapKind represents a map literal expression.
     Map(MapExpr),

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -33,6 +33,9 @@ pub use ser::SerializationError;
 
 #[cfg(feature = "json")]
 mod json;
+mod optimize;
+pub use optimize::Optimizer;
+
 #[cfg(feature = "json")]
 pub use json::ConvertToJsonError;
 
@@ -166,6 +169,17 @@ impl Program {
         parser
             .parse(source)
             .map(|expression| Program { expression })
+    }
+
+    pub fn optimized(self) -> Program {
+        Program {
+            expression: crate::optimize::Optimize::new().optimize(self.expression),
+        }
+    }
+    pub fn optimized_with<T: Optimizer + 'static>(self, t: T) -> Program {
+        Program {
+            expression: crate::optimize::Optimize::new_with_optimizer(t).optimize(self.expression),
+        }
     }
 
     pub fn execute(&self, context: &Context) -> ResolveResult {

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -787,6 +787,7 @@ impl Value {
     pub fn resolve(expr: &Expression, ctx: &Context) -> ResolveResult {
         match &expr.expr {
             Expr::Literal(val) => Ok(val.clone().into()),
+            Expr::Inline(val) => Ok(val.clone()),
             Expr::Call(call) => {
                 if call.args.len() == 3 && call.func_name == operators::CONDITIONAL {
                     let cond = Value::resolve(&call.args[0], ctx)?;

--- a/cel/src/optimize.rs
+++ b/cel/src/optimize.rs
@@ -1,0 +1,272 @@
+use crate::common::ast::{
+    CallExpr, ComprehensionExpr, EntryExpr, Expr, IdedEntryExpr, ListExpr, MapEntryExpr, MapExpr,
+    SelectExpr,
+};
+use crate::objects::{Key, Map};
+use crate::parser::Expression;
+use crate::{IdedExpr, Value};
+use std::sync::Arc;
+
+fn is_lit(e: &Expr) -> bool {
+    matches!(e, Expr::Literal(_) | Expr::Inline(_) | Expr::Map(_))
+}
+
+fn as_value(e: IdedExpr) -> Value {
+    assert!(is_lit(&e.expr));
+    match e.expr {
+        Expr::Literal(l) => Value::from(l),
+        Expr::Inline(l) => l,
+        _ => unreachable!(),
+    }
+}
+
+/// An Optimizer is an input to the optimization process that defines user-specific optimizations.
+/// While the default universal optimizations apply automatically, Optimizer allows specialized optimizations.
+pub trait Optimizer {
+    /// optimize will be called on each node *after* default optimizations, such as inlining, are done.
+    /// Because this is called for each node, rather than just the top level expression, traversing the AST
+    /// is not necessary.
+    fn optimize(&self, _expr: &Expr) -> Option<Expr> {
+        None
+    }
+}
+
+struct DefaultOptimizer;
+impl Optimizer for DefaultOptimizer {}
+
+pub struct Optimize {
+    optimizer: Box<dyn Optimizer>,
+}
+
+impl Optimize {
+    pub fn new() -> Self {
+        Self {
+            optimizer: Box::new(DefaultOptimizer),
+        }
+    }
+    pub fn new_with_optimizer<T: Optimizer + 'static>(t: T) -> Self {
+        Self {
+            optimizer: Box::new(t),
+        }
+    }
+
+    pub fn optimize(&self, expr: Expression) -> Expression {
+        let id = expr.id;
+        let with_id = |expr: Expr| Expression { id, expr };
+        match expr.expr {
+            Expr::Call(c) => {
+                let target = c.target.map(|t| Box::new(self.optimize(*t)));
+                let args = c
+                    .args
+                    .into_iter()
+                    .map(|a| self.optimize(a))
+                    .collect::<Vec<_>>();
+                let call = CallExpr {
+                    target,
+                    args,
+                    func_name: c.func_name,
+                };
+                let expr = Expr::Call(call);
+                with_id(self.optimizer.optimize(&expr).unwrap_or(expr))
+            }
+            Expr::Comprehension(c) => {
+                let expr = Expr::Comprehension(Box::new(ComprehensionExpr {
+                    iter_range: self.optimize(c.iter_range),
+                    iter_var: c.iter_var,
+                    iter_var2: c.iter_var2,
+                    accu_var: c.accu_var,
+                    accu_init: self.optimize(c.accu_init),
+                    loop_cond: self.optimize(c.loop_cond),
+                    loop_step: self.optimize(c.loop_step),
+                    result: self.optimize(c.result),
+                }));
+                with_id(self.optimizer.optimize(&expr).unwrap_or(expr))
+            }
+            Expr::Select(s) => {
+                let expr = Expr::Select(SelectExpr {
+                    operand: Box::new(self.optimize(*s.operand)),
+                    field: s.field,
+                    test: s.test,
+                });
+                with_id(self.optimizer.optimize(&expr).unwrap_or(expr))
+            }
+            Expr::Struct(_) => {
+                todo!()
+            }
+            Expr::List(v) => {
+                let nl: Vec<IdedExpr> = v.elements.into_iter().map(|a| self.optimize(a)).collect();
+                let expr = if nl.iter().all(|nl| is_lit(&nl.expr)) {
+                    Expr::Inline(Value::List(Arc::new(
+                        nl.into_iter().map(as_value).collect(),
+                    )))
+                } else {
+                    Expr::List(ListExpr {
+                        elements: nl,
+                        optional_indices: v.optional_indices,
+                    })
+                };
+                with_id(self.optimizer.optimize(&expr).unwrap_or(expr))
+            }
+            Expr::Map(m) => {
+                let ne: Vec<IdedEntryExpr> = m
+                    .entries
+                    .into_iter()
+                    .map(|e| match e.expr {
+                        EntryExpr::MapEntry(me) => {
+                            let value = self.optimize(me.value);
+                            let key = self.optimize(me.key);
+                            let ne = MapEntryExpr {
+                                value,
+                                key,
+                                optional: me.optional,
+                            };
+                            IdedEntryExpr {
+                                id: e.id,
+                                expr: EntryExpr::MapEntry(ne),
+                            }
+                        }
+                        _ => unreachable!(),
+                    })
+                    .collect();
+                let expr = if ne.iter().all(|nl| match &nl.expr {
+                    EntryExpr::MapEntry(me) => is_lit(&me.key.expr) && is_lit(&me.value.expr),
+                    _ => unreachable!(),
+                }) {
+                    let m: std::collections::HashMap<Key, Value> = ne
+                        .into_iter()
+                        .map(|e| match e.expr {
+                            EntryExpr::MapEntry(me) => (
+                                as_value(me.key).try_into().expect("must be a valid key"),
+                                as_value(me.value),
+                            ),
+                            _ => unreachable!(),
+                        })
+                        .collect();
+                    Expr::Inline(Value::Map(Map { map: Arc::new(m) }))
+                } else {
+                    Expr::Map(MapExpr { entries: ne })
+                };
+                with_id(self.optimizer.optimize(&expr).unwrap_or(expr))
+            }
+            Expr::Literal(value) => {
+                let expr = Expr::Inline(Value::from(value));
+                with_id(self.optimizer.optimize(&expr).unwrap_or(expr))
+            }
+            expr => with_id(self.optimizer.optimize(&expr).unwrap_or(expr)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::common::ast::{CallExpr, Expr};
+    use crate::extractors::This;
+    use crate::objects::Opaque;
+    use crate::{objects, Context, ExecutionError, IdedExpr, Program, Value};
+    use std::sync::Arc;
+
+    pub struct RegexOptimizer;
+    impl RegexOptimizer {
+        fn specialize_call(&self, c: &CallExpr) -> Option<Expr> {
+            fn expr_as_value(e: IdedExpr) -> Option<Value> {
+                match e.expr {
+                    Expr::Literal(l) => Some(Value::from(l)),
+                    Expr::Inline(l) => Some(l),
+                    _ => None,
+                }
+            }
+            match c.func_name.as_str() {
+                "matches" if c.args.len() == 1 && c.target.is_some() => {
+                    let t = c.target.clone()?;
+                    let arg = c.args.first()?.clone();
+                    let id = arg.id;
+                    let Value::String(arg) = expr_as_value(arg)? else {
+                        return None;
+                    };
+
+                    // TODO: translate regex compile failures into inlined failures
+                    let opaque =
+                        Value::Opaque(Arc::new(PrecompileRegex(regex::Regex::new(&arg).ok()?)));
+                    let id_expr = IdedExpr {
+                        id,
+                        expr: Expr::Inline(opaque),
+                    };
+                    // We invert this to be 'regex.precompiled_matches(string)'
+                    // instead of 'string.matches(regex)'
+                    Some(Expr::Call(CallExpr {
+                        func_name: "precompiled_matches".to_string(),
+                        target: Some(Box::new(id_expr)),
+                        args: vec![*t],
+                    }))
+                }
+                _ => None,
+            }
+        }
+    }
+
+    impl crate::Optimizer for RegexOptimizer {
+        fn optimize(&self, c: &Expr) -> Option<Expr> {
+            match c {
+                Expr::Call(c) => self.specialize_call(c),
+                _ => None,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct PrecompileRegex(regex::Regex);
+    impl objects::Opaque for PrecompileRegex {
+        #[inline]
+        fn runtime_type_name(&self) -> &str {
+            "precompiled_regex"
+        }
+
+        #[cfg(feature = "json")]
+        fn json(&self) -> Option<serde_json::Value> {
+            None
+        }
+    }
+    impl PartialEq for PrecompileRegex {
+        fn eq(&self, other: &Self) -> bool {
+            self.0.as_str() == other.0.as_str()
+        }
+    }
+    impl Eq for PrecompileRegex {}
+
+    impl PrecompileRegex {
+        pub fn precompiled_matches(
+            this: This<Arc<dyn Opaque>>,
+            val: Arc<String>,
+        ) -> Result<bool, ExecutionError> {
+            let Some(rgx) = this.0.downcast_ref::<Self>() else {
+                return Err(ExecutionError::UnexpectedType {
+                    got: this.0.runtime_type_name().to_string(),
+                    want: "regex".to_string(),
+                });
+            };
+            Ok(rgx.0.is_match(&val))
+        }
+    }
+
+    #[test]
+    fn test_optimize_function() {
+        let mut context = Context::default();
+        context.add_function("precompiled_matches", PrecompileRegex::precompiled_matches);
+
+        let program = Program::compile("'foo'.matches('fo.')")
+            .unwrap()
+            .optimized_with(RegexOptimizer);
+        let value = program.execute(&context);
+        assert_eq!(value, Ok(Value::Bool(true)));
+        let Expr::Call(CallExpr {
+            func_name,
+            target: Some(t),
+            ..
+        }) = program.expression.expr
+        else {
+            panic!("expected optimization, got {program:?}");
+        };
+        assert_eq!(func_name.as_str(), "precompiled_matches");
+        assert!(matches!(t.expr, Expr::Inline(Value::Opaque(_))));
+    }
+}

--- a/cel/src/parser/parser.rs
+++ b/cel/src/parser/parser.rs
@@ -2144,6 +2144,7 @@ ERROR: <input>:1:24: unsupported syntax '?'
                     self.push("]");
                     &format!("^#{}:{}#", expr.id, "*expr.Expr_ListExpr")
                 }
+                Expr::Inline(_val) => todo!(),
                 Expr::Literal(val) => match val {
                     CelVal::String(s) => {
                         &format!("\"{s}\"^#{}:{}#", expr.id, "*expr.Constant_StringValue")

--- a/cel/src/parser/references.rs
+++ b/cel/src/parser/references.rs
@@ -121,6 +121,7 @@ impl IdedExpr {
                 }
             }
             Expr::Literal(_) => {}
+            Expr::Inline(_) => {}
             Expr::Map(map) => {
                 for entry in &map.entries {
                     match &entry.expr {


### PR DESCRIPTION
This PR exposes a new `Program::optimized` function that modifies a Programmed into an 'optimized' one. What 'optimized' means can change over time, but for now its rudimentary but effective. 

Currently, any `Expr::Literal`s need to be cloned into `Value`s during resolve time. This PR adds a new enum variant, `Expr::Inline(Value)` that directly holds a Value. During resolve time, we just clone the Value (which is a ref count). We do this by traversing the tree and converting any literals to inline values. For lists/maps, if all elements in the collection are literals we can also turn them into inlined lists/maps.

A further optimization is to have specialized functions. For example, `"foo".matches("fo.*")` can be precompile into an Opaque value wrapping `regex::Regex` allowing the regex to be precompile. A possible out-of-tree library that exposes something like (`cidr("127.0.0.1/8").includes("127.0.0.6")`) could precompile the CIDR in a similar manner. I've included the regex in this PR, though I suspect this is something we should consider not including in-tree. Instead, users can either write their own `optimize()` function, or we can possible provide some helpers so they can just implement a function `fn specialize_call(c: CallExpr) -> CallExpr` to do this (to avoid the need to do the full AST traversal, which is kind of annoying).

This is a prototype to get some feedback on if we want to do this, and how.

Benchmark results:

```
execute/ternary_1       time:   [11.665 ns 11.742 ns 12.050 ns]
                        change: [-34.540% -33.391% -32.240%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/ternary_2       time:   [11.985 ns 11.986 ns 11.990 ns]
                        change: [-33.519% -33.454% -33.388%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/or_1            time:   [6.7827 ns 6.8316 ns 7.0273 ns]
                        change: [-51.208% -50.299% -49.389%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/and_1           time:   [6.6762 ns 6.7264 ns 6.9273 ns]
                        change: [-52.336% -51.419% -50.501%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/and_2           time:   [6.6310 ns 6.6399 ns 6.6422 ns]
                        change: [-52.720% -52.649% -52.578%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/number          time:   [3.9995 ns 4.0057 ns 4.0306 ns]
                        change: [-44.682% -44.410% -44.136%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/construct_list  time:   [12.550 ns 12.593 ns 12.764 ns]
                        change: [-76.077% -75.853% -75.630%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/construct_list_1
                        time:   [12.505 ns 12.522 ns 12.526 ns]
                        change: [-59.165% -59.106% -59.049%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/construct_list_2
                        time:   [12.493 ns 12.538 ns 12.549 ns]
                        change: [-70.517% -70.399% -70.289%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/add_list        time:   [89.954 ns 90.103 ns 90.698 ns]
                        change: [-33.901% -33.583% -33.269%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/list_element    time:   [24.315 ns 24.345 ns 24.466 ns]
                        change: [-59.169% -59.005% -58.842%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/construct_dict  time:   [12.500 ns 12.518 ns 12.587 ns]
                        change: [-86.407% -86.346% -86.288%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/add_string      time:   [60.312 ns 60.361 ns 60.556 ns]
                        change: [-0.7066% -0.3996% -0.0893%] (p = 0.39 > 0.05)
                        No change in performance detected.
execute/list            time:   [63.195 ns 63.609 ns 63.713 ns]
                        change: [+3.9527% +4.4674% +4.9747%] (p = 0.01 < 0.05)
                        Performance has regressed.
execute/mapexpr         time:   [35.484 ns 35.691 ns 35.743 ns]
                        change: [-9.9824% -9.4319% -8.8921%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/map_merge       time:   [30.643 ns 30.683 ns 30.693 ns]
                        change: [-80.053% -79.992% -79.935%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/size_list       time:   [66.267 ns 66.568 ns 66.643 ns]
                        change: [-12.097% -11.712% -11.321%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/size_list_1     time:   [88.841 ns 88.917 ns 89.220 ns]
                        change: [-20.657% -20.406% -20.147%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/size_str        time:   [65.968 ns 66.031 ns 66.283 ns]
                        change: [-1.4256% -0.3492% +0.7292%] (p = 0.76 > 0.05)
                        No change in performance detected.
execute/size_str_2      time:   [87.749 ns 87.826 ns 88.135 ns]
                        change: [+6.4603% +6.8412% +7.2024%] (p = 0.00 < 0.05)
                        Performance has regressed.
execute/size_map        time:   [65.384 ns 65.549 ns 65.590 ns]
                        change: [-30.321% -29.987% -29.629%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/size_map_2      time:   [87.656 ns 88.463 ns 88.664 ns]
                        change: [-46.311% -45.922% -45.534%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/member          time:   [57.630 ns 57.953 ns 58.034 ns]
                        change: [+8.4983% +9.5818% +10.503%] (p = 0.00 < 0.05)
                        Performance has regressed.
execute/map has         time:   [62.196 ns 62.316 ns 62.793 ns]
                        change: [+7.2137% +7.8487% +8.4763%] (p = 0.00 < 0.05)
                        Performance has regressed.
execute/map macro       time:   [690.50 ns 692.23 ns 699.15 ns]
                        change: [+3.5806% +4.3994% +5.2187%] (p = 0.01 < 0.05)
                        Performance has regressed.
execute/filter macro    time:   [593.12 ns 593.66 ns 593.79 ns]
                        change: [+2.5049% +2.8900% +3.2548%] (p = 0.01 < 0.05)
                        Performance has regressed.
execute/all macro       time:   [542.06 ns 545.53 ns 546.39 ns]
                        change: [+3.2480% +3.7365% +4.2243%] (p = 0.01 < 0.05)
                        Performance has regressed.
execute/all map macro   time:   [595.74 ns 597.88 ns 598.41 ns]
                        change: [+5.0378% +5.4167% +5.7862%] (p = 0.00 < 0.05)
                        Performance has regressed.
execute/max             time:   [88.768 ns 88.778 ns 88.820 ns]
                        change: [-6.3900% -6.2329% -6.0822%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/max negative    time:   [88.117 ns 88.236 ns 88.266 ns]
                        change: [-7.8984% -7.7032% -7.5064%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/max float       time:   [87.283 ns 87.670 ns 89.218 ns]
                        change: [-9.0937% -7.9616% -6.8455%] (p = 0.02 < 0.05)
                        Performance has improved.
execute/duration        time:   [91.573 ns 91.630 ns 91.859 ns]
                        change: [-12.735% -11.155% -9.8684%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/timestamp       time:   [102.71 ns 102.79 ns 103.13 ns]
                        change: [-7.3084% -6.9921% -6.6704%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/stress          time:   [618.88 ns 619.10 ns 620.00 ns]
                        change: [-35.684% -35.592% -35.497%] (p = 0.00 < 0.05)
                        Performance has improved.
execute/regex           time:   [117.96 ns 118.54 ns 120.86 ns]
                        change: [-97.729% -97.699% -97.668%] (p = 0.00 < 0.05)
                        Performance has improved.
``