### PR TITLE
opaque: minor tweaks to make usage more ergonomic

### DIFF
--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -1,5 +1,4 @@
-use crate::magic::{Function, FunctionRegistry};
-pub use crate::magic::{IntoFunction, IntoResolveResult};
+use crate::magic::{Function, FunctionRegistry, IntoFunction};
 use crate::objects::{TryIntoValue, Value};
 use crate::parser::Expression;
 use crate::{functions, ExecutionError};

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -40,6 +40,8 @@ use magic::FromContext;
 
 pub mod extractors {
     pub use crate::magic::{Arguments, Identifier, This};
+
+    pub use crate::magic::{IntoFunction, IntoResolveResult};
 }
 
 #[derive(Error, Clone, Debug, PartialEq)]


### PR DESCRIPTION
This contains two changes:
1. Add conversion for `Arc<dyn Opaque>`
2. Expose `IntoFunction` and `IntoResolveResult`.

The purpse of this is to allow function writers to write normal functions, and have helper functions do the shimming to the opaque logic.

For example, one shim I am using:

```rust
pub fn wrap1<F, T, V>(f: F) -> Function
where
	F: Fn(&T) -> V + Send + Sync + 'static,
	V: cel::context::IntoResolveResult,
	T: Opaque + TypeName + 'static + Send + Sync,
{
	let closure = move |This(this): This<Value>| {
		let this = as_opaque(this)?;
		f(cast::<T>(&this)?).into_resolve_result()
	};
	cel::context::IntoFunction::into_function(closure)
}
```