### PR TITLE
perf: avoid cloning function args and name

### DIFF
--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -16,20 +16,20 @@ type Result<T> = std::result::Result<T, ExecutionError>;
 /// a method), the program context ([`Context`]) which gives functions access
 /// to variables, and the arguments to the function call.
 #[derive(Clone)]
-pub struct FunctionContext<'context> {
-    pub name: Arc<String>,
+pub struct FunctionContext<'context, 'call: 'context> {
+    pub name: &'call str,
     pub this: Option<Value>,
     pub ptx: &'context Context<'context>,
-    pub args: Vec<Expression>,
+    pub args: &'call [Expression],
     pub arg_idx: usize,
 }
 
-impl<'context> FunctionContext<'context> {
+impl<'context, 'call: 'context> FunctionContext<'context, 'call> {
     pub fn new(
-        name: Arc<String>,
+        name: &'call str,
         this: Option<Value>,
         ptx: &'context Context<'context>,
-        args: Vec<Expression>,
+        args: &'call [Expression],
     ) -> Self {
         Self {
             name,
@@ -50,7 +50,7 @@ impl<'context> FunctionContext<'context> {
 
     /// Returns an execution error for the currently execution function.
     pub fn error<M: ToString>(&self, message: M) -> ExecutionError {
-        ExecutionError::function_error(self.name.as_str(), message)
+        ExecutionError::function_error(self.name, message)
     }
 }
 

--- a/cel/src/macros.rs
+++ b/cel/src/macros.rs
@@ -47,8 +47,8 @@ macro_rules! impl_conversions {
                 }
             }
 
-            impl<'a, 'context> FromContext<'a, 'context> for $target_type {
-                fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+            impl<'a, 'context, 'call> FromContext<'a, 'context, 'call> for $target_type {
+                fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
                 where
                     Self: Sized,
                 {
@@ -66,7 +66,7 @@ macro_rules! impl_handler {
             impl<F, $($t,)* R> IntoFunction<($($t,)*)> for F
             where
                 F: Fn($($t,)*) -> R + Send + Sync + 'static,
-                $($t: for<'a, 'context> $crate::FromContext<'a, 'context>,)*
+                $($t: for<'a, 'context, 'call> $crate::FromContext<'a, 'context, 'call>,)*
                 R: IntoResolveResult,
             {
                 fn into_function(self) -> Function {
@@ -82,7 +82,7 @@ macro_rules! impl_handler {
             impl<F, $($t,)* R> IntoFunction<(WithFunctionContext, $($t,)*)> for F
             where
                 F: Fn(&FunctionContext, $($t,)*) -> R + Send + Sync + 'static,
-                $($t: for<'a, 'context> $crate::FromContext<'a, 'context>,)*
+                $($t: for<'a, 'context, 'call> $crate::FromContext<'a, 'context, 'call>,)*
                 R: IntoResolveResult,
             {
                 fn into_function(self) -> Function {

--- a/cel/src/magic.rs
+++ b/cel/src/magic.rs
@@ -71,8 +71,8 @@ impl IntoResolveResult for Result<Value, ExecutionError> {
 /// be used as arguments to functions. This trait is core to the 'magic function
 /// parameter' system. Every argument to a function that can be registered to
 /// the CEL context must implement this type.
-pub(crate) trait FromContext<'a, 'context> {
-    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+pub(crate) trait FromContext<'a, 'context, 'call> {
+    fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
     where
         Self: Sized;
 }
@@ -129,11 +129,11 @@ pub(crate) trait FromContext<'a, 'context> {
 /// ```
 pub struct This<T>(pub T);
 
-impl<'a, 'context, T> FromContext<'a, 'context> for This<T>
+impl<'a, 'context, 'call, T> FromContext<'a, 'context, 'call> for This<T>
 where
     T: FromValue,
 {
-    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+    fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
     where
         Self: Sized,
     {
@@ -178,8 +178,8 @@ where
 #[derive(Clone)]
 pub struct Identifier(pub Arc<String>);
 
-impl<'a, 'context> FromContext<'a, 'context> for Identifier {
-    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+impl<'a, 'context, 'call> FromContext<'a, 'context, 'call> for Identifier {
+    fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
     where
         Self: Sized,
     {
@@ -231,7 +231,7 @@ impl From<Identifier> for String {
 #[derive(Clone)]
 pub struct Arguments(pub Arc<Vec<Value>>);
 
-impl<'a> FromContext<'a, '_> for Arguments {
+impl<'a> FromContext<'a, '_, '_> for Arguments {
     fn from_context(ctx: &'a mut FunctionContext) -> Result<Self, ExecutionError>
     where
         Self: Sized,
@@ -243,8 +243,8 @@ impl<'a> FromContext<'a, '_> for Arguments {
     }
 }
 
-impl<'a, 'context> FromContext<'a, 'context> for Value {
-    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+impl<'a, 'context, 'call> FromContext<'a, 'context, 'call> for Value {
+    fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
     where
         Self: Sized,
     {
@@ -252,8 +252,8 @@ impl<'a, 'context> FromContext<'a, 'context> for Value {
     }
 }
 
-impl<'a, 'context> FromContext<'a, 'context> for Expression {
-    fn from_context(ctx: &'a mut FunctionContext<'context>) -> Result<Self, ExecutionError>
+impl<'a, 'context, 'call> FromContext<'a, 'context, 'call> for Expression {
+    fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
     where
         Self: Sized,
     {

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -813,20 +813,15 @@ impl Value {
                 })?;
                 match &call.target {
                     None => {
-                        let mut ctx = FunctionContext::new(
-                            call.func_name.clone().into(),
-                            None,
-                            ctx,
-                            call.args.clone(),
-                        );
+                        let mut ctx = FunctionContext::new(&call.func_name, None, ctx, &call.args);
                         (func)(&mut ctx)
                     }
                     Some(target) => {
                         let mut ctx = FunctionContext::new(
-                            call.func_name.clone().into(),
+                            &call.func_name,
                             Some(Value::resolve(target, ctx)?),
                             ctx,
-                            call.args.clone(),
+                            &call.args,
                         );
                         (func)(&mut ctx)
                     }


### PR DESCRIPTION
These can be passed as a reference. This shaves about 70ns off a simple expression call (~20% of the runtime).

Technically FunctionContext is `pub` so this is a breaking change... however, I don't see why anyone would rely on these?