### PR TITLE
Add new way to resolve variables

### DIFF
--- a/cel/benches/runtime.rs
+++ b/cel/benches/runtime.rs
@@ -67,7 +67,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             let mut ctx = Context::default();
             ctx.add_variable_from_value("foo", HashMap::from([("bar", 1)]));
             ctx.add_variable_from_value("apple", true);
-            ctx.set_variable_resolver(std::sync::Arc::new(Resolver));
+            ctx.set_variable_resolver(&Resolver);
             b.iter(|| program.execute(&ctx))
         });
     }

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -222,12 +222,12 @@ impl Default for Context<'_> {
 /// # Example
 /// ```
 /// struct ValueContext {
-///     request: Value,
-///     response: Value,
+///     request: cel::Value,
+///     response: cel::Value,
 /// }
 ///
-/// impl VariableResolver for ValueContext {
-///     fn resolve(&self, variable: &str) -> Option<Value> {
+/// impl cel::context::VariableResolver for ValueContext {
+///     fn resolve(&self, variable: &str) -> Option<cel::Value> {
 ///         match variable {
 ///             "request" => Some(self.request.clone()),
 ///             "response" => Some(self.response.clone()),


### PR DESCRIPTION
runtime execution:
```
execute/variable resolver
                        time:   [4.3831 ns 4.3913 ns 4.3934 ns]
execute/variable hashmap
                        time:   [12.091 ns 12.390 ns 12.464 ns]
```

Time to build a new context, with 10 variables: `500ns-->82ns`