### PR TITLE
refactor: default to BTree's instead of HashMap

### DIFF
--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -2,7 +2,7 @@ use crate::magic::{Function, FunctionRegistry, IntoFunction};
 use crate::objects::{TryIntoValue, Value};
 use crate::parser::Expression;
 use crate::{functions, ExecutionError};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Context is a collection of variables and functions that can be used
 /// by the interpreter to resolve expressions.
@@ -32,11 +32,11 @@ use std::collections::HashMap;
 pub enum Context<'a> {
     Root {
         functions: FunctionRegistry,
-        variables: HashMap<String, Value>,
+        variables: BTreeMap<String, Value>,
     },
     Child {
         parent: &'a Context<'a>,
-        variables: HashMap<String, Value>,
+        variables: BTreeMap<String, Value>,
     },
 }
 

--- a/cel/src/magic.rs
+++ b/cel/src/magic.rs
@@ -2,7 +2,7 @@ use crate::common::ast::Expr;
 use crate::macros::{impl_conversions, impl_handler};
 use crate::resolvers::{AllArguments, Argument};
 use crate::{ExecutionError, Expression, FunctionContext, ResolveResult, Value};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 impl_conversions!(
@@ -303,7 +303,7 @@ impl_handler!(C1, C2, C3, C4, C5, C6, C7, C8, C9);
 
 #[derive(Default)]
 pub struct FunctionRegistry {
-    functions: HashMap<String, Function>,
+    functions: BTreeMap<String, Function>,
 }
 
 impl FunctionRegistry {


### PR DESCRIPTION
 Sort of a follow up to #229 

 This will be cheaper on lookups where the number of variables or
 functions is "relatively small".

 Single variable contexts get a -68.197% perf improvement
 Disclaimer: Not a scientific test case (i.e. on a MBP on MacOS)
