### PR TITLE
feat(Optional): Initial support

### DIFF
--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -162,6 +162,7 @@ impl Default for Context<'_> {
         ctx.add_function("double", functions::double);
         ctx.add_function("int", functions::int);
         ctx.add_function("uint", functions::uint);
+        ctx.add_function("optional.none", functions::optional_none);
 
         #[cfg(feature = "regex")]
         ctx.add_function("matches", functions::matches);

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -1,6 +1,6 @@
 use crate::context::Context;
 use crate::magic::{Arguments, This};
-use crate::objects::Value;
+use crate::objects::{OptionalValue, Value};
 use crate::parser::Expression;
 use crate::resolvers::Resolver;
 use crate::ExecutionError;
@@ -221,6 +221,13 @@ pub fn int(ftx: &FunctionContext, This(this): This<Value>) -> Result<Value> {
         Value::UInt(v) => Value::Int(v.try_into().map_err(|_| ftx.error("integer overflow"))?),
         v => return Err(ftx.error(format!("cannot convert {v:?} to int"))),
     })
+}
+
+pub fn optional_none(ftx: &FunctionContext) -> Result<Value> {
+    if ftx.this.is_some() || !ftx.args.is_empty() {
+        return Err(ftx.error("unsupported function"));
+    }
+    Ok(Value::Opaque(Arc::new(OptionalValue::none())))
 }
 
 /// Returns true if a string starts with another string.


### PR DESCRIPTION
 - Allow for qualified function names and dispatching
 - Created `OptionalValue` to be used within a `Value::Opaque`
 - Added support for `optional.none()` fn call

Mostly as a heads up and more examples of using `Opaque`s.
Missing are: 
 - [ ] all optional functions
 - [ ] make use of the `OptionalValue` in the parser