### PR TITLE
feat: support for bytes::Bytes

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -18,6 +18,7 @@ regex = { version = "1.10.5", optional = true }
 serde = "1.0"
 serde_json = { version = "1.0", optional = true }
 base64 = { version = "0.22.1", optional = true }
+bytes = { version = "1", optional = true }
 
 thiserror = "1.0"
 paste = "1.0"
@@ -33,6 +34,7 @@ harness = false
 
 [features]
 default = ["regex", "chrono"]
+bytes = ["dep:bytes"]
 json = ["dep:serde_json", "dep:base64"]
 regex = ["dep:regex"]
 chrono = ["dep:chrono"]

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -624,6 +624,22 @@ impl From<Vec<u8>> for Value {
     }
 }
 
+#[cfg(feature = "bytes")]
+// Convert Bytes to Value
+impl From<::bytes::Bytes> for Value {
+    fn from(v: ::bytes::Bytes) -> Self {
+        Value::Bytes(v.to_vec().into())
+    }
+}
+
+#[cfg(feature = "bytes")]
+// Convert &Bytes to Value
+impl From<&::bytes::Bytes> for Value {
+    fn from(v: &::bytes::Bytes) -> Self {
+        Value::Bytes(v.to_vec().into())
+    }
+}
+
 // Convert String to Value
 impl From<String> for Value {
     fn from(v: String) -> Self {


### PR DESCRIPTION
bytes::Bytes is a thin, cheaply clonable wrapper for Vec<u8> that is used in many crates of the tokio ecosystem, including prost, which gives the user the option to generate all protobuf `bytes` fields as `Bytes` rather than `Vec<u8>`.

In this PR I've added a `TryFrom<Bytes>` impl for `Value`, so that it can be used seamlessly in cel programs, without breaking other blanket impls like `From<Vec<T>> where T: Into<Value>` or `From<HashMap<K, V>> where V: Into<Value>`.