### PR TITLE
chore: update minimal rust version to 1.86

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/cel-rust/cel-rust"
 version = "0.12.0"
 authors = ["Clark McCauley <me@clarkmccauley.com>", "Alex Snaps <alex@wcgw.dev>"]
 edition = "2021"
-rust-version = "1.82.0"
+rust-version = "1.86.0"
 license = "MIT"
 categories = ["compilers"]
 


### PR DESCRIPTION
Fixes #248 