### PR TITLE
performance: use key references

### DIFF
--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -1,6 +1,6 @@
 use crate::context::Context;
 use crate::magic::{Arguments, This};
-use crate::objects::{OptionalValue, Value};
+use crate::objects::{KeyRef, OptionalValue, Value};
 use crate::parser::Expression;
 use crate::resolvers::Resolver;
 use crate::ExecutionError;
@@ -117,9 +117,9 @@ pub fn size(ftx: &FunctionContext, This(this): This<Value>) -> Result<i64> {
 pub fn contains(This(this): This<Value>, arg: Value) -> Result<Value> {
     Ok(match this {
         Value::List(v) => v.contains(&arg),
-        Value::Map(v) => v
-            .map
-            .contains_key(&arg.try_into().map_err(ExecutionError::UnsupportedKeyType)?),
+        Value::Map(v) => {
+            v.contains_key(&KeyRef::try_from(&arg).map_err(ExecutionError::UnsupportedKeyType)?)
+        }
         Value::String(s) => {
             if let Value::String(arg) = arg {
                 s.contains(arg.as_str())


### PR DESCRIPTION
Supercedes https://github.com/cel-rust/cel-rust/pull/173. This does the same, but with a new KeyRef that is `Borrow` for `Key`. This is tricky to do, following the tricks in https://github.com/sunshowers-code/borrow-complex-key-example (with hashbrown its trivial).

In that PR there was discussion around not doing this anyways since it was going to become obsolete but not sure if that is the case, especially now that this is not a breaking change

```
execute/member          time:   [48.975 ns 48.975 ns 48.977 ns]
                        change: [-22.751% -22.033% -21.303%] (p = 0.05 > 0.05)
                        No change in performance detected.
execute/map has         time:   [54.521 ns 54.690 ns 55.369 ns]
                        change: [-23.335% -21.860% -20.351%] (p = 0.07 > 0.05)
```