### PR TITLE
refactor(build): slightly optimize dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = ["cel", "example", "fuzz"]
 resolver = "2"
 
+[profile.dev]
+opt-level = 1
+
 [profile.bench]
 lto = true
 codegen-units = 1

--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -39,3 +39,6 @@ json = ["dep:serde_json", "dep:base64"]
 regex = ["dep:regex"]
 chrono = ["dep:chrono"]
 dhat-heap = [ ] # if you are doing heap profiling
+
+[profile.dev]
+opt-level = 1


### PR DESCRIPTION
I've been spending some time looking at stack usage. But couldn't find any low hanging fruits sadly. 
While there are some types I can off load to the heap more, this ends up making no real difference. It's mostly all due to how deep the stack gets due to how ANTLR does this, which the Rust implementation does just as other do, e.g. the golang generated parser is just has deep. 

Currently for a `[1]` a nested call from CEL's perspective is actually ~21 frames on the stack per "nested expressions".

Slightly optimizing the dev builds, we get to ~223 deep expressions, with a grand total of almost 4.5k frames (!) on the stack, with a 2MB stack size.

<details>

```rust
use std::thread;
use cel::parser::Parser;

fn main() {
  thread::spawn(|| {
    let mut cel = "1".to_string();
    let mut depth = 0;
    loop {
      depth += 1;
      cel = format!("[{cel}]");
      println!("Depth {depth:02}: {cel}");
      let parser = Parser::new().max_recursion_depth(u16::MAX); // note: defaulting to 96
      parser.parse(&mut cel).expect("must parse!");
    }
  }).join().unwrap();
}
```
</details>