### PR TITLE
Overloads

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -39,6 +39,3 @@ json = ["dep:serde_json", "dep:base64"]
 regex = ["dep:regex"]
 chrono = ["dep:chrono"]
 dhat-heap = [ ] # if you are doing heap profiling
-
-[profile.dev]
-opt-level = 1

--- a/cel/src/common/decls.rs
+++ b/cel/src/common/decls.rs
@@ -1,24 +1,64 @@
-use crate::common::functions::{Op, Overload};
-use crate::common::traits::TraitSet;
+use crate::common::functions::Function;
 use crate::common::types::Type;
 use crate::common::value::Val;
+use std::collections::btree_map::Entry::{Occupied, Vacant};
 use std::collections::BTreeMap;
 
 pub struct FunctionDecl<'a> {
-    name: String,
+    pub name: String,
     overloads: BTreeMap<String, OverloadDecl<'a>>,
-    singleton: Overload,
 }
 
-struct OverloadDecl<'a> {
-    id: String,
-    arg_types: Vec<&'a Type<'a>>,
-    result_type: &'a Type<'a>,
+impl<'a> FunctionDecl<'a> {
+    pub fn new(name: &str) -> FunctionDecl<'a> {
+        FunctionDecl {
+            name: name.to_string(),
+            overloads: BTreeMap::default(),
+        }
+    }
+
+    pub fn find_overload(&self, member_function: bool, arg_types: &[Type<'a>]) -> Option<Function> {
+        for overload in self.overloads.values() {
+            if overload.member_function == member_function && overload.arg_types == arg_types {
+                return Some(overload.op);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn add_overload(
+        &mut self,
+        id: String,
+        member_function: bool,
+        arg_types: Vec<Type<'a>>,
+        op: Function,
+    ) -> Result<(), ()> {
+        match self.overloads.entry(id) {
+            Vacant(vacant_entry) => {
+                let id = vacant_entry.key().clone();
+                vacant_entry.insert(OverloadDecl {
+                    id,
+                    arg_types,
+                    member_function,
+                    op,
+                });
+                Ok(())
+            }
+            Occupied(_) => Err(()),
+        }
+    }
+}
+
+pub struct OverloadDecl<'a> {
+    pub id: String,
+    arg_types: Vec<Type<'a>>,
+    //result_type: &'a Type<'a>,
     member_function: bool,
-    operand_traits: TraitSet,
-    op: Op,
+    //operand_traits: TraitSet,
+    op: Function,
 }
 
+#[allow(dead_code)]
 struct VariableDecl<'a, 'b> {
     name: String,
     var_type: &'a Type<'a>,

--- a/cel/src/common/decls.rs
+++ b/cel/src/common/decls.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::common::functions::Function;
 use crate::common::types::Type;
 use crate::common::value::Val;
@@ -15,9 +17,16 @@ impl<'a> FunctionDecl<'a> {
         }
     }
 
-    pub fn find_overload(&self, member_function: bool, arg_types: &[Type<'a>]) -> Option<Function> {
+    pub fn find_overload(&self, member_function: bool, args: &[Cow<dyn Val>]) -> Option<Function> {
         for overload in &self.overloads {
-            if overload.member_function == member_function && overload.arg_types == arg_types {
+            if overload.member_function == member_function
+                && args.len() == overload.arg_types.len()
+                && overload
+                    .arg_types
+                    .iter()
+                    .enumerate()
+                    .all(|(i, t)| t.is_assignable(args[i].as_ref()))
+            {
                 return Some(overload.op);
             }
         }

--- a/cel/src/common/decls.rs
+++ b/cel/src/common/decls.rs
@@ -1,24 +1,22 @@
 use crate::common::functions::Function;
 use crate::common::types::Type;
 use crate::common::value::Val;
-use std::collections::btree_map::Entry::{Occupied, Vacant};
-use std::collections::BTreeMap;
 
 pub struct FunctionDecl<'a> {
     pub name: String,
-    overloads: BTreeMap<String, OverloadDecl<'a>>,
+    overloads: Vec<OverloadDecl<'a>>,
 }
 
 impl<'a> FunctionDecl<'a> {
     pub fn new(name: &str) -> FunctionDecl<'a> {
         FunctionDecl {
             name: name.to_string(),
-            overloads: BTreeMap::default(),
+            overloads: Vec::default(),
         }
     }
 
     pub fn find_overload(&self, member_function: bool, arg_types: &[Type<'a>]) -> Option<Function> {
-        for overload in self.overloads.values() {
+        for overload in &self.overloads {
             if overload.member_function == member_function && overload.arg_types == arg_types {
                 return Some(overload.op);
             }
@@ -33,19 +31,27 @@ impl<'a> FunctionDecl<'a> {
         arg_types: Vec<Type<'a>>,
         op: Function,
     ) -> Result<(), ()> {
-        match self.overloads.entry(id) {
-            Vacant(vacant_entry) => {
-                let id = vacant_entry.key().clone();
-                vacant_entry.insert(OverloadDecl {
-                    id,
-                    arg_types,
-                    member_function,
-                    op,
-                });
-                Ok(())
-            }
-            Occupied(_) => Err(()),
+        if self.is_present(&id, member_function, &arg_types) {
+            return Err(());
         }
+        self.overloads.push(OverloadDecl {
+            id,
+            arg_types,
+            member_function,
+            op,
+        });
+        Ok(())
+    }
+
+    fn is_present(&self, name: &str, member_function: bool, arg_types: &[Type<'a>]) -> bool {
+        for overload in &self.overloads {
+            if overload.id == name
+                || (overload.member_function == member_function && overload.arg_types == arg_types)
+            {
+                return true;
+            }
+        }
+        false
     }
 }
 

--- a/cel/src/common/decls.rs
+++ b/cel/src/common/decls.rs
@@ -1,0 +1,26 @@
+use crate::common::functions::{Op, Overload};
+use crate::common::traits::TraitSet;
+use crate::common::types::Type;
+use crate::common::value::Val;
+use std::collections::BTreeMap;
+
+pub struct FunctionDecl<'a> {
+    name: String,
+    overloads: BTreeMap<String, OverloadDecl<'a>>,
+    singleton: Overload,
+}
+
+struct OverloadDecl<'a> {
+    id: String,
+    arg_types: Vec<&'a Type<'a>>,
+    result_type: &'a Type<'a>,
+    member_function: bool,
+    operand_traits: TraitSet,
+    op: Op,
+}
+
+struct VariableDecl<'a, 'b> {
+    name: String,
+    var_type: &'a Type<'a>,
+    value: &'b dyn Val,
+}

--- a/cel/src/common/functions.rs
+++ b/cel/src/common/functions.rs
@@ -10,4 +10,4 @@ pub struct Overload {
     op: Function,
 }
 
-pub type Function = for<'a> fn(&[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError>;
+pub type Function = for<'a> fn(Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError>;

--- a/cel/src/common/functions.rs
+++ b/cel/src/common/functions.rs
@@ -1,0 +1,21 @@
+use crate::common::traits::TraitSet;
+use crate::common::value::Val;
+use crate::ExecutionError;
+use std::borrow::Cow;
+
+pub struct Overload {
+    operator: String,
+    operand_trait: TraitSet,
+    op: Op,
+}
+
+// todo, probably don't want 'static here, but... for now
+pub(crate) enum Op {
+    Unary(UnaryOp<'static>),
+    Binary(BinaryOp<'static>),
+    Function(Function<'static>),
+}
+
+type UnaryOp<'a> = fn(&dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;
+type BinaryOp<'a> = fn(&dyn Val, &dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;
+type Function<'a> = fn(&[&dyn Val]) -> Result<Cow<'a, dyn Val>, ExecutionError>;

--- a/cel/src/common/functions.rs
+++ b/cel/src/common/functions.rs
@@ -3,19 +3,11 @@ use crate::common::value::Val;
 use crate::ExecutionError;
 use std::borrow::Cow;
 
+#[allow(dead_code)]
 pub struct Overload {
     operator: String,
     operand_trait: TraitSet,
-    op: Op,
+    op: Function,
 }
 
-// todo, probably don't want 'static here, but... for now
-pub(crate) enum Op {
-    Unary(UnaryOp<'static>),
-    Binary(BinaryOp<'static>),
-    Function(Function<'static>),
-}
-
-type UnaryOp<'a> = fn(Cow<dyn Val>) -> Result<Cow<'a, dyn Val>, ExecutionError>;
-type BinaryOp<'a> = fn(Cow<dyn Val>, Cow<dyn Val>) -> Result<Cow<'a, dyn Val>, ExecutionError>;
-type Function<'a> = fn(&[Cow<dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError>;
+pub type Function = for<'a> fn(&[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError>;

--- a/cel/src/common/functions.rs
+++ b/cel/src/common/functions.rs
@@ -16,6 +16,6 @@ pub(crate) enum Op {
     Function(Function<'static>),
 }
 
-type UnaryOp<'a> = fn(&dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;
-type BinaryOp<'a> = fn(&dyn Val, &dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;
-type Function<'a> = fn(&[&dyn Val]) -> Result<Cow<'a, dyn Val>, ExecutionError>;
+type UnaryOp<'a> = fn(Cow<dyn Val>) -> Result<Cow<'a, dyn Val>, ExecutionError>;
+type BinaryOp<'a> = fn(Cow<dyn Val>, Cow<dyn Val>) -> Result<Cow<'a, dyn Val>, ExecutionError>;
+type Function<'a> = fn(&[Cow<dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError>;

--- a/cel/src/common/mod.rs
+++ b/cel/src/common/mod.rs
@@ -1,4 +1,6 @@
 pub mod ast;
+pub mod decls;
+pub mod functions;
 pub mod traits;
 pub mod types;
 pub mod value;

--- a/cel/src/common/traits.rs
+++ b/cel/src/common/traits.rs
@@ -5,53 +5,55 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 
+pub type TraitSet = u16;
+
 /// ADDER_TYPE types provide a '+' operator overload.
-pub const ADDER_TYPE: u16 = 1;
+pub const ADDER_TYPE: TraitSet = 1;
 
 /// COMPARER_TYPE types support ordering comparisons '<', '<=', '>', '>='.
-pub const COMPARER_TYPE: u16 = ADDER_TYPE << 1;
+pub const COMPARER_TYPE: TraitSet = ADDER_TYPE << 1;
 
 /// CONTAINER_TYPE types support 'in' operations.
-pub const CONTAINER_TYPE: u16 = COMPARER_TYPE << 1;
+pub const CONTAINER_TYPE: TraitSet = COMPARER_TYPE << 1;
 
 /// DIVIDER_TYPE types support '/' operations.
-pub const DIVIDER_TYPE: u16 = CONTAINER_TYPE << 1;
+pub const DIVIDER_TYPE: TraitSet = CONTAINER_TYPE << 1;
 
 /// FIELD_TESTER_TYPE types support the detection of field value presence.
-pub const FIELD_TESTER_TYPE: u16 = DIVIDER_TYPE << 1;
+pub const FIELD_TESTER_TYPE: TraitSet = DIVIDER_TYPE << 1;
 
 /// INDEXER_TYPE types support index access with dynamic values.
-pub const INDEXER_TYPE: u16 = FIELD_TESTER_TYPE << 1;
+pub const INDEXER_TYPE: TraitSet = FIELD_TESTER_TYPE << 1;
 
 /// ITERABLE_TYPE types can be iterated over in comprehensions.
-pub const ITERABLE_TYPE: u16 = INDEXER_TYPE << 1;
+pub const ITERABLE_TYPE: TraitSet = INDEXER_TYPE << 1;
 
 /// ITERATOR_TYPE types support iterator semantics.
-pub const ITERATOR_TYPE: u16 = ITERABLE_TYPE << 1;
+pub const ITERATOR_TYPE: TraitSet = ITERABLE_TYPE << 1;
 
 /// MATCHER_TYPE types support pattern matching via 'matches' method.
-pub const MATCHER_TYPE: u16 = ITERATOR_TYPE << 1;
+pub const MATCHER_TYPE: TraitSet = ITERATOR_TYPE << 1;
 
 /// MODDER_TYPE types support modulus operations '%'
-pub const MODDER_TYPE: u16 = MATCHER_TYPE << 1;
+pub const MODDER_TYPE: TraitSet = MATCHER_TYPE << 1;
 
 /// MULTIPLIER_TYPE types support '*' operations.
-pub const MULTIPLIER_TYPE: u16 = MODDER_TYPE << 1;
+pub const MULTIPLIER_TYPE: TraitSet = MODDER_TYPE << 1;
 
 /// NEGATOR_TYPE types support either negation via '!' or '-'
-pub const NEGATOR_TYPE: u16 = MULTIPLIER_TYPE << 1;
+pub const NEGATOR_TYPE: TraitSet = MULTIPLIER_TYPE << 1;
 
 /// RECEIVER_TYPE types support dynamic dispatch to instance methods.
-pub const RECEIVER_TYPE: u16 = NEGATOR_TYPE << 1;
+pub const RECEIVER_TYPE: TraitSet = NEGATOR_TYPE << 1;
 
 /// SIZER_TYPE types support the size() method.
-pub const SIZER_TYPE: u16 = RECEIVER_TYPE << 1;
+pub const SIZER_TYPE: TraitSet = RECEIVER_TYPE << 1;
 
 /// SUBTRACTOR_TYPE types support '-' operations.
-pub const SUBTRACTOR_TYPE: u16 = SIZER_TYPE << 1;
+pub const SUBTRACTOR_TYPE: TraitSet = SIZER_TYPE << 1;
 
 /// FOLDABLE_TYPE types support comprehensions v2 macros which iterate over (key, value) pairs.
-pub const FOLDABLE_TYPE: u16 = SUBTRACTOR_TYPE << 1;
+pub const FOLDABLE_TYPE: TraitSet = SUBTRACTOR_TYPE << 1;
 
 pub trait Adder {
     fn add<'a>(&'a self, _rhs: &dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;

--- a/cel/src/common/traits.rs
+++ b/cel/src/common/traits.rs
@@ -1,3 +1,4 @@
+use crate::common::types::CelInt;
 use crate::common::value::Val;
 use crate::ExecutionError;
 use std::any::Any;
@@ -91,6 +92,10 @@ pub trait Negator {
     fn negate(&self) -> Result<Box<dyn Val>, ExecutionError>;
 }
 
+pub trait Sizer {
+    fn size(&self) -> CelInt;
+}
+
 pub trait Subtractor {
     fn sub<'a>(&'a self, _rhs: &'_ dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;
 }
@@ -103,4 +108,21 @@ pub trait Indexer {
 
 pub trait Lister: Debug + Any {
     fn as_indexer(&self) -> &dyn Indexer;
+}
+
+pub(crate) mod adapter {
+    use std::borrow::Cow;
+
+    use crate::{common::value::Val, ExecutionError};
+
+    pub fn sizer_size<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+        let target = &args[0];
+        match target.as_sizer() {
+            None => Err(ExecutionError::UnexpectedType {
+                got: target.get_type().name().to_owned(),
+                want: "missing trait Sizer".to_owned(),
+            }),
+            Some(sizer) => Ok(Cow::<dyn Val>::Owned(Box::new(sizer.size()))),
+        }
+    }
 }

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -1,4 +1,4 @@
-use crate::common::types::{CelInt, Type};
+use crate::common::types::{CelInt, CelString, Type};
 use crate::common::value::Val;
 use crate::Value;
 use crate::{common::traits, ExecutionError};
@@ -120,7 +120,38 @@ fn size<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionErro
     }
 }
 
+fn bytes_to_bytes<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    Ok(args[0].clone())
+}
+
+fn string_to_bytes<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    match args[0].as_ref().downcast_ref::<CelString>() {
+        Some(arg) => {
+            let value = arg.as_bytes().to_vec();
+            Ok(Cow::<dyn Val>::Owned(Box::new(Bytes::from(value))))
+        }
+        None => Err(ExecutionError::UnexpectedType {
+            got: args[0].get_type().name().to_owned(),
+            want: "Bytes".to_owned(),
+        }),
+    }
+}
+
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "bytes",
+        "string_to_bytes",
+        vec![super::STRING_TYPE],
+        string_to_bytes,
+    )
+    .expect("Must be unique id");
+    env.add_overload(
+        "bytes",
+        "bytes_to_bytes",
+        vec![super::BYTES_TYPE],
+        bytes_to_bytes,
+    )
+    .expect("Must be unique id");
     env.add_overload("size", "size_bytes", vec![super::BYTES_TYPE], size)
         .expect("Must be unique id");
     env.add_member_overload("size", "bytes_size", super::BYTES_TYPE, vec![], size)

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -108,7 +108,7 @@ impl<'a> TryFrom<&'a dyn Val> for &'a [u8] {
     }
 }
 
-pub(crate) fn size_fn<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+pub(crate) fn size<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     match args[0].as_ref().downcast_ref::<Bytes>() {
         Some(arg) => Ok(Cow::<dyn Val>::Owned(Box::new(CelInt::from(
             arg.len() as i64

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -108,7 +108,7 @@ impl<'a> TryFrom<&'a dyn Val> for &'a [u8] {
     }
 }
 
-fn size<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+fn size<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     match args[0].as_ref().downcast_ref::<Bytes>() {
         Some(arg) => Ok(Cow::<dyn Val>::Owned(Box::new(CelInt::from(
             arg.len() as i64
@@ -120,11 +120,12 @@ fn size<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionErro
     }
 }
 
-fn bytes_to_bytes<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-    Ok(args[0].clone())
+fn bytes_to_bytes<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    Ok(args.remove(0))
 }
 
-fn string_to_bytes<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+fn string_to_bytes<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     match args[0].as_ref().downcast_ref::<CelString>() {
         Some(arg) => {
             let value = arg.as_bytes().to_vec();

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -1,5 +1,5 @@
 use crate::common::types::{CelInt, CelString, Type};
-use crate::common::value::Val;
+use crate::common::value::{Downcast, Val};
 use crate::Value;
 use crate::{common::traits, ExecutionError};
 use std::borrow::Cow;
@@ -126,13 +126,15 @@ fn bytes_to_bytes<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, E
 }
 
 fn string_to_bytes<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-    match args[0].as_ref().downcast_ref::<CelString>() {
-        Some(arg) => {
-            let value = arg.as_bytes().to_vec();
+    let mut args = args;
+    let arg = args.remove(0).into_owned();
+    match arg.downcast::<CelString>() {
+        Ok(arg) => {
+            let value = arg.into_inner().into_bytes();
             Ok(Cow::<dyn Val>::Owned(Box::new(Bytes::from(value))))
         }
-        None => Err(ExecutionError::UnexpectedType {
-            got: args[0].get_type().name().to_owned(),
+        Err(e) => Err(ExecutionError::UnexpectedType {
+            got: e.get_type().name().to_owned(),
             want: "Bytes".to_owned(),
         }),
     }

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -1,7 +1,7 @@
-use crate::common::traits;
-use crate::common::types::Type;
+use crate::common::types::{CelInt, Type};
 use crate::common::value::Val;
 use crate::Value;
+use crate::{common::traits, ExecutionError};
 use std::borrow::Cow;
 use std::ops::Deref;
 use traits::{Adder, Comparer};
@@ -105,5 +105,17 @@ impl<'a> TryFrom<&'a dyn Val> for &'a [u8] {
             return Ok(bytes.inner());
         }
         Err(value)
+    }
+}
+
+pub(crate) fn size_fn<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    match args[0].as_ref().downcast_ref::<Bytes>() {
+        Some(arg) => Ok(Cow::<dyn Val>::Owned(Box::new(CelInt::from(
+            arg.len() as i64
+        )))),
+        None => Err(ExecutionError::UnexpectedType {
+            got: args[0].get_type().name().to_owned(),
+            want: "Bytes".to_owned(),
+        }),
     }
 }

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -108,7 +108,7 @@ impl<'a> TryFrom<&'a dyn Val> for &'a [u8] {
     }
 }
 
-pub(crate) fn size<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+fn size<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     match args[0].as_ref().downcast_ref::<Bytes>() {
         Some(arg) => Ok(Cow::<dyn Val>::Owned(Box::new(CelInt::from(
             arg.len() as i64
@@ -118,4 +118,11 @@ pub(crate) fn size<'a>(args: &[Cow<'a, dyn Val>]) -> Result<Cow<'a, dyn Val>, Ex
             want: "Bytes".to_owned(),
         }),
     }
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload("size", "size_bytes", vec![super::BYTES_TYPE], size)
+        .expect("Must be unique id");
+    env.add_member_overload("size", "bytes_size", super::BYTES_TYPE, vec![], size)
+        .expect("Must be unique id");
 }

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -1,3 +1,4 @@
+use crate::common::traits::Sizer;
 use crate::common::types::{CelInt, CelString, Type};
 use crate::common::value::{Downcast, Val};
 use crate::Value;
@@ -40,6 +41,10 @@ impl Val for Bytes {
         Some(self)
     }
 
+    fn as_sizer(&self) -> Option<&dyn Sizer> {
+        Some(self)
+    }
+
     fn equals(&self, other: &dyn Val) -> bool {
         other
             .downcast_ref::<Self>()
@@ -77,6 +82,12 @@ impl Comparer for Bytes {
     }
 }
 
+impl Sizer for Bytes {
+    fn size(&self) -> CelInt {
+        (self.inner().len() as i64).into()
+    }
+}
+
 impl From<Vec<u8>> for Bytes {
     fn from(value: Vec<u8>) -> Self {
         Bytes(value)
@@ -105,18 +116,6 @@ impl<'a> TryFrom<&'a dyn Val> for &'a [u8] {
             return Ok(bytes.inner());
         }
         Err(value)
-    }
-}
-
-fn size<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-    match args[0].as_ref().downcast_ref::<Bytes>() {
-        Some(arg) => Ok(Cow::<dyn Val>::Owned(Box::new(CelInt::from(
-            arg.len() as i64
-        )))),
-        None => Err(ExecutionError::UnexpectedType {
-            got: args[0].get_type().name().to_owned(),
-            want: "Bytes".to_owned(),
-        }),
     }
 }
 
@@ -155,8 +154,19 @@ pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
         bytes_to_bytes,
     )
     .expect("Must be unique id");
-    env.add_overload("size", "size_bytes", vec![super::BYTES_TYPE], size)
-        .expect("Must be unique id");
-    env.add_member_overload("size", "bytes_size", super::BYTES_TYPE, vec![], size)
-        .expect("Must be unique id");
+    env.add_overload(
+        "size",
+        "size_bytes",
+        vec![super::BYTES_TYPE],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+    env.add_member_overload(
+        "size",
+        "bytes_size",
+        super::BYTES_TYPE,
+        vec![],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
 }

--- a/cel/src/common/types/list.rs
+++ b/cel/src/common/types/list.rs
@@ -234,6 +234,24 @@ impl<'a> traits::Iterator<'a> for SliceIterator<'a> {
     }
 }
 
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "size",
+        "size_list",
+        vec![super::LIST_TYPE],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+    env.add_member_overload(
+        "size",
+        "list_size",
+        super::LIST_TYPE,
+        vec![],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+}
+
 #[cfg(test)]
 pub mod tests {
     use crate::common::traits::Indexer;

--- a/cel/src/common/types/list.rs
+++ b/cel/src/common/types/list.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Adder, Container, Indexer, Iterable};
+use crate::common::traits::{Adder, Container, Indexer, Iterable, Sizer};
 use crate::common::types::{CelInt, CelUInt, Type};
 use crate::common::value::Val;
 use crate::common::{traits, types};
@@ -58,6 +58,10 @@ impl Val for DefaultList {
     }
 
     fn as_iterable(&self) -> Option<&dyn Iterable> {
+        Some(self)
+    }
+
+    fn as_sizer(&self) -> Option<&dyn Sizer> {
         Some(self)
     }
 
@@ -173,6 +177,12 @@ impl Indexer for DefaultList {
 impl Iterable for DefaultList {
     fn iter<'a>(&'a self) -> Box<dyn super::traits::Iterator<'a> + 'a> {
         Box::new(SliceIterator::new(self.0.as_slice()))
+    }
+}
+
+impl Sizer for DefaultList {
+    fn size(&self) -> CelInt {
+        (self.inner().len() as i64).into()
     }
 }
 

--- a/cel/src/common/types/map.rs
+++ b/cel/src/common/types/map.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Container, Indexer, Iterable};
+use crate::common::traits::{Container, Indexer, Iterable, Sizer};
 use crate::common::types::{CelBool, CelInt, CelString, CelUInt, Type};
 use crate::common::value::Val;
 use crate::common::{traits, types};
@@ -51,6 +51,10 @@ impl Val for DefaultMap {
     }
 
     fn as_iterable(&self) -> Option<&dyn Iterable> {
+        Some(self)
+    }
+
+    fn as_sizer(&self) -> Option<&dyn Sizer> {
         Some(self)
     }
 
@@ -132,6 +136,12 @@ impl Indexer for DefaultMap {
 impl Iterable for DefaultMap {
     fn iter<'a>(&'a self) -> Box<dyn super::traits::Iterator<'a> + 'a> {
         Box::new(MapKeyIterator::new(self.0.keys()))
+    }
+}
+
+impl Sizer for DefaultMap {
+    fn size(&self) -> CelInt {
+        (self.inner().len() as i64).into()
     }
 }
 

--- a/cel/src/common/types/map.rs
+++ b/cel/src/common/types/map.rs
@@ -377,3 +377,21 @@ impl<'a> traits::Iterator<'a> for MapKeyIterator<'a> {
         self.keys.next().map(|k| k.inner())
     }
 }
+
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "size",
+        "size_map",
+        vec![super::MAP_TYPE],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+    env.add_member_overload(
+        "size",
+        "map_size",
+        super::MAP_TYPE,
+        vec![],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+}

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -66,6 +66,12 @@ pub struct Type<'a> {
     trait_mask: TraitSet,
 }
 
+impl Type<'_> {
+    pub fn kind(&self) -> Kind {
+        self.kind
+    }
+}
+
 pub const ANY_TYPE: Type = Type {
     kind: Kind::Any,
     parameters: &[],

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -67,6 +67,12 @@ pub struct Type<'a> {
 }
 
 impl Type<'_> {
+    pub fn is_assignable(&self, val: &dyn Val) -> bool {
+        *self == val.get_type()
+    }
+}
+
+impl Type<'_> {
     pub fn kind(&self) -> Kind {
         self.kind
     }

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -7,11 +7,11 @@ mod double;
 #[cfg(feature = "chrono")]
 mod duration;
 mod int;
-mod list;
-mod map;
+pub(crate) mod list;
+pub(crate) mod map;
 mod null;
 mod optional;
-mod string;
+pub(crate) mod string;
 #[cfg(feature = "chrono")]
 mod timestamp;
 mod uint;

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -2,7 +2,7 @@ use crate::common::traits;
 use std::any::Any;
 
 pub(crate) mod bool;
-mod bytes;
+pub(crate) mod bytes;
 mod double;
 #[cfg(feature = "chrono")]
 mod duration;

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -16,6 +16,7 @@ mod string;
 mod timestamp;
 mod uint;
 
+use crate::common::traits::TraitSet;
 use crate::common::value::Val;
 pub use bool::Bool as CelBool;
 pub use bytes::Bytes as CelBytes;
@@ -62,7 +63,7 @@ pub struct Type<'a> {
     kind: Kind,
     parameters: &'a [&'a Type<'a>],
     runtime_type_name: &'a str,
-    trait_mask: u16,
+    trait_mask: TraitSet,
 }
 
 pub const ANY_TYPE: Type = Type {

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -125,6 +125,24 @@ impl<'a> TryFrom<&'a dyn Val> for &'a str {
     }
 }
 
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "size",
+        "size_string",
+        vec![super::STRING_TYPE],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+    env.add_member_overload(
+        "size",
+        "string_size",
+        super::STRING_TYPE,
+        vec![],
+        traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+}
+
 #[cfg(test)]
 mod tests {
     use super::StdString;

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -1,5 +1,5 @@
-use crate::common::traits::{Adder, Comparer};
-use crate::common::types::Type;
+use crate::common::traits::{self, Adder, Comparer, Sizer};
+use crate::common::types::{CelInt, Type};
 use crate::common::value::Val;
 use crate::ExecutionError;
 use std::borrow::Cow;
@@ -41,6 +41,10 @@ impl Val for String {
         Some(self)
     }
 
+    fn as_sizer(&self) -> Option<&dyn Sizer> {
+        Some(self)
+    }
+
     fn equals(&self, other: &dyn Val) -> bool {
         other
             .downcast_ref::<Self>()
@@ -76,6 +80,12 @@ impl Comparer for String {
         } else {
             Err(ExecutionError::NoSuchOverload)
         }
+    }
+}
+
+impl Sizer for String {
+    fn size(&self) -> CelInt {
+        (self.inner().len() as i64).into()
     }
 }
 

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -1,5 +1,6 @@
 use crate::common::traits::{
-    Adder, Comparer, Container, Divider, Indexer, Iterable, Modder, Multiplier, Negator, Subtractor,
+    Adder, Comparer, Container, Divider, Indexer, Iterable, Modder, Multiplier, Negator, Sizer,
+    Subtractor,
 };
 use crate::common::types::Type;
 use std::any::Any;
@@ -45,6 +46,10 @@ pub trait Val: Any + Debug + Send + Sync {
     }
 
     fn as_negator(&self) -> Option<&dyn Negator> {
+        None
+    }
+
+    fn as_sizer(&self) -> Option<&dyn Sizer> {
         None
     }
 

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -65,6 +65,23 @@ impl dyn Val {
     }
 }
 
+pub trait Downcast {
+    type Error;
+
+    fn downcast<T: Val>(self) -> Result<Box<T>, Self::Error>;
+}
+
+impl Downcast for Box<dyn Val> {
+    type Error = Self;
+
+    fn downcast<T: Val>(self) -> Result<Box<T>, Self> {
+        if <dyn Any + 'static>::is::<T>(self.as_ref()) {
+            return Ok(<Box<dyn Any>>::downcast::<T>(self).expect("we just tested it is!"));
+        }
+        Err(self)
+    }
+}
+
 impl ToOwned for dyn Val {
     type Owned = Box<dyn Val>;
 

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -99,6 +99,8 @@ impl PartialEq for dyn Val {
 #[cfg(test)]
 mod test {
     use crate::common::types;
+    use crate::common::types::CelString;
+    use crate::common::value::Downcast;
     use crate::common::value::Val;
     use std::borrow::Cow;
 
@@ -116,5 +118,10 @@ mod test {
         assert!(test(borrowed.as_ref()));
         assert!(test(cow.as_ref()));
         assert!(test(borrowed.clone().as_ref()));
+        assert_eq!(cow.downcast_ref::<CelString>().unwrap().inner(), "cel");
+        let boxed = cow.into_owned();
+        let s: CelString = *boxed.downcast::<CelString>().unwrap();
+        let s: String = s.into();
+        assert_eq!(s.as_str(), "cel");
     }
 }

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -239,7 +239,6 @@ impl Default for Context<'_> {
         ctx.add_function("startsWith", functions::starts_with);
         ctx.add_function("endsWith", functions::ends_with);
         ctx.add_function("string", functions::string);
-        ctx.add_function("bytes", functions::bytes);
         ctx.add_function("double", functions::double);
         ctx.add_function("int", functions::int);
         ctx.add_function("uint", functions::uint);

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -233,7 +233,6 @@ impl Default for Context<'_> {
         };
 
         ctx.add_function("contains", functions::contains);
-        ctx.add_function("size", functions::size);
         ctx.add_function("max", functions::max);
         ctx.add_function("min", functions::min);
         ctx.add_function("startsWith", functions::starts_with);

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -2,7 +2,7 @@ use crate::common::value::Val;
 use crate::magic::{Function, FunctionRegistry, IntoFunction};
 use crate::objects::{TryIntoValue, Value};
 use crate::parser::Expression;
-use crate::{functions, ExecutionError};
+use crate::{functions, Env, ExecutionError};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -37,6 +37,7 @@ pub enum Context<'a> {
         functions: FunctionRegistry,
         variables: BTreeMap<String, Box<dyn Val>>,
         resolver: Option<&'a dyn VariableResolver>,
+        env: Arc<Env<'a>>,
     },
     Child {
         parent: &'a Context<'a>,
@@ -152,6 +153,13 @@ impl<'a> Context<'a> {
         }
     }
 
+    pub(crate) fn env(&self) -> &Env<'_> {
+        match self {
+            Context::Root { env, .. } => env.as_ref(),
+            Context::Child { parent, .. } => parent.env(),
+        }
+    }
+
     #[allow(dead_code)]
     pub(crate) fn get_function(&self, name: &str) -> Option<&Function> {
         match self {
@@ -198,6 +206,16 @@ impl<'a> Context<'a> {
     /// ```
     pub fn empty() -> Self {
         Context::Root {
+            env: Arc::new(Env::default()),
+            variables: Default::default(),
+            functions: Default::default(),
+            resolver: None,
+        }
+    }
+
+    pub fn with_env(env: Arc<Env<'a>>) -> Self {
+        Context::Root {
+            env,
             variables: Default::default(),
             functions: Default::default(),
             resolver: None,
@@ -208,6 +226,7 @@ impl<'a> Context<'a> {
 impl Default for Context<'_> {
     fn default() -> Self {
         let mut ctx = Context::Root {
+            env: Arc::new(Env::stdlib()),
             variables: Default::default(),
             functions: Default::default(),
             resolver: None,

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -1,5 +1,12 @@
-use crate::common::decls::FunctionDecl;
-use std::collections::BTreeMap;
+use crate::common::{
+    decls::FunctionDecl,
+    functions::Function,
+    types::{self, Type},
+};
+use std::collections::{
+    btree_map::Entry::{Occupied, Vacant},
+    BTreeMap,
+};
 
 #[derive(Default)]
 pub struct Env<'a> {
@@ -8,7 +15,53 @@ pub struct Env<'a> {
 
 impl<'a> Env<'a> {
     pub fn stdlib() -> Env<'a> {
-        Env::default()
+        let mut env = Env::default();
+        env.add_overload(
+            "size",
+            "size_bytes",
+            vec![types::BYTES_TYPE],
+            types::bytes::size_fn,
+        ).expect("Must be unique id");
+        env
+    }
+
+    #[allow(clippy::result_unit_err)]
+    pub fn add_overload(
+        &mut self,
+        name: &str,
+        id: &str,
+        args: Vec<types::Type<'a>>,
+        op: Function,
+    ) -> Result<(), ()> {
+        match self.functions.entry(name.to_owned()) {
+            Vacant(vacant_entry) => {
+                let mut value = FunctionDecl::new(name);
+                value.add_overload(id.to_string(), false, args, op)?;
+                vacant_entry.insert(value);
+                Ok(())
+            }
+            Occupied(occupied_entry) => {
+                occupied_entry
+                    .into_mut()
+                    .add_overload(id.to_string(), false, args, op)
+            }
+        }
+    }
+
+    pub fn find_overload(&self, name: &str, args: &[Type<'_>]) -> Option<Function> {
+        match self.functions.get(name) {
+            None => None,
+            Some(fn_decl) => fn_decl.find_overload(false, args),
+        }
+    }
+
+    pub fn find_member_overload(
+        &self,
+        _name: &str,
+        _target: Type<'_>,
+        _args: &[Type<'_>],
+    ) -> Option<Function> {
+        None
     }
 }
 

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -2,10 +2,14 @@ use crate::common::{
     decls::FunctionDecl,
     functions::Function,
     types::{self, Type},
+    value::Val,
 };
-use std::collections::{
-    btree_map::Entry::{Occupied, Vacant},
-    BTreeMap,
+use std::{
+    borrow::Cow,
+    collections::{
+        btree_map::Entry::{Occupied, Vacant},
+        BTreeMap,
+    },
 };
 
 #[derive(Default)]
@@ -46,7 +50,7 @@ impl<'a> Env<'a> {
         }
     }
 
-    pub fn find_overload(&self, name: &str, args: &[Type<'_>]) -> Option<Function> {
+    pub fn find_overload(&self, name: &str, args: &[Cow<dyn Val>]) -> Option<Function> {
         match self.functions.get(name) {
             None => None,
             Some(fn_decl) => fn_decl.find_overload(false, args),
@@ -79,7 +83,7 @@ impl<'a> Env<'a> {
         }
     }
 
-    pub fn find_member_overload(&self, name: &str, args: &[Type<'_>]) -> Option<Function> {
+    pub fn find_member_overload(&self, name: &str, args: &[Cow<dyn Val>]) -> Option<Function> {
         match self.functions.get(name) {
             None => None,
             Some(fn_decl) => fn_decl.find_overload(true, args),

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -21,7 +21,8 @@ impl<'a> Env<'a> {
             "size_bytes",
             vec![types::BYTES_TYPE],
             types::bytes::size_fn,
-        ).expect("Must be unique id");
+        )
+        .expect("Must be unique id");
         env
     }
 

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -20,7 +20,15 @@ impl<'a> Env<'a> {
             "size",
             "size_bytes",
             vec![types::BYTES_TYPE],
-            types::bytes::size_fn,
+            types::bytes::size,
+        )
+        .expect("Must be unique id");
+        env.add_member_overload(
+            "size",
+            "bytes_size",
+            types::BYTES_TYPE,
+            vec![],
+            types::bytes::size,
         )
         .expect("Must be unique id");
         env
@@ -56,13 +64,45 @@ impl<'a> Env<'a> {
         }
     }
 
+    #[allow(clippy::result_unit_err)]
+    pub fn add_member_overload(
+        &mut self,
+        name: &str,
+        id: &str,
+        target: Type<'a>,
+        args: Vec<types::Type<'a>>,
+        op: Function,
+    ) -> Result<(), ()> {
+        let mut args = args;
+        args.insert(0, target);
+        match self.functions.entry(name.to_owned()) {
+            Vacant(vacant_entry) => {
+                let mut value = FunctionDecl::new(name);
+                value.add_overload(id.to_string(), true, args, op)?;
+                vacant_entry.insert(value);
+                Ok(())
+            }
+            Occupied(occupied_entry) => {
+                occupied_entry
+                    .into_mut()
+                    .add_overload(id.to_string(), true, args, op)
+            }
+        }
+    }
+
     pub fn find_member_overload(
         &self,
-        _name: &str,
-        _target: Type<'_>,
-        _args: &[Type<'_>],
+        name: &str,
+        target: Type<'_>,
+        args: &[Type<'_>],
     ) -> Option<Function> {
-        None
+        let mut arg_types = Vec::with_capacity(args.len());
+        arg_types.push(target);
+        arg_types.extend_from_slice(args);
+        match self.functions.get(name) {
+            None => None,
+            Some(fn_decl) => fn_decl.find_overload(true, &arg_types),
+        }
     }
 }
 

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -17,6 +17,9 @@ impl<'a> Env<'a> {
     pub fn stdlib() -> Env<'a> {
         let mut env = Env::default();
         types::bytes::stdlib(&mut env);
+        types::list::stdlib(&mut env);
+        types::map::stdlib(&mut env);
+        types::string::stdlib(&mut env);
         env
     }
 

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -16,21 +16,7 @@ pub struct Env<'a> {
 impl<'a> Env<'a> {
     pub fn stdlib() -> Env<'a> {
         let mut env = Env::default();
-        env.add_overload(
-            "size",
-            "size_bytes",
-            vec![types::BYTES_TYPE],
-            types::bytes::size,
-        )
-        .expect("Must be unique id");
-        env.add_member_overload(
-            "size",
-            "bytes_size",
-            types::BYTES_TYPE,
-            vec![],
-            types::bytes::size,
-        )
-        .expect("Must be unique id");
+        types::bytes::stdlib(&mut env);
         env
     }
 

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -1,0 +1,24 @@
+use crate::common::decls::FunctionDecl;
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+pub struct Env<'a> {
+    functions: BTreeMap<String, FunctionDecl<'a>>,
+}
+
+impl<'a> Env<'a> {
+    pub fn stdlib() -> Env<'a> {
+        Env::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_env_default() {
+        let _: Arc<dyn Send + Sync> = Arc::new(Env::default());
+    }
+}

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -90,18 +90,10 @@ impl<'a> Env<'a> {
         }
     }
 
-    pub fn find_member_overload(
-        &self,
-        name: &str,
-        target: Type<'_>,
-        args: &[Type<'_>],
-    ) -> Option<Function> {
-        let mut arg_types = Vec::with_capacity(args.len());
-        arg_types.push(target);
-        arg_types.extend_from_slice(args);
+    pub fn find_member_overload(&self, name: &str, args: &[Type<'_>]) -> Option<Function> {
         match self.functions.get(name) {
             None => None,
-            Some(fn_decl) => fn_decl.find_overload(true, &arg_types),
+            Some(fn_decl) => fn_decl.find_overload(true, args),
         }
     }
 }

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -78,7 +78,6 @@ pub fn size(ftx: &FunctionContext, This(this): This<Value>) -> Result<i64> {
         Value::List(l) => l.len(),
         Value::Map(m) => m.map.len(),
         Value::String(s) => s.len(),
-        Value::Bytes(b) => b.len(),
         value => return Err(ftx.error(format!("cannot determine the size of {value:?}"))),
     };
     Ok(size as i64)

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -1,7 +1,6 @@
 use crate::context::Context;
 use crate::magic::{Arguments, This};
 use crate::objects::{KeyRef, OptionalValue, Value};
-use crate::parser::Expression;
 use crate::resolvers::Resolver;
 use crate::ExecutionError;
 use std::borrow::Cow;
@@ -21,7 +20,7 @@ pub struct FunctionContext<'context, 'call: 'context> {
     pub name: &'call str,
     pub this: Option<Cow<'context, dyn Val>>,
     pub ptx: &'context Context<'context>,
-    pub args: &'call [Expression],
+    pub args: Vec<Cow<'context, dyn Val>>,
     pub arg_idx: usize,
 }
 
@@ -30,7 +29,7 @@ impl<'context, 'call: 'context> FunctionContext<'context, 'call> {
         name: &'call str,
         this: Option<Cow<'context, dyn Val>>,
         ptx: &'context Context<'context>,
-        args: &'call [Expression],
+        args: Vec<Cow<'context, dyn Val>>,
     ) -> Self {
         Self {
             name,

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -4,6 +4,7 @@ use crate::objects::{KeyRef, OptionalValue, Value};
 use crate::parser::Expression;
 use crate::resolvers::Resolver;
 use crate::ExecutionError;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -18,7 +19,7 @@ type Result<T> = std::result::Result<T, ExecutionError>;
 #[derive(Clone)]
 pub struct FunctionContext<'context, 'call: 'context> {
     pub name: &'call str,
-    pub this: Option<Value>,
+    pub this: Option<Cow<'context, dyn Val>>,
     pub ptx: &'context Context<'context>,
     pub args: &'call [Expression],
     pub arg_idx: usize,
@@ -27,7 +28,7 @@ pub struct FunctionContext<'context, 'call: 'context> {
 impl<'context, 'call: 'context> FunctionContext<'context, 'call> {
     pub fn new(
         name: &'call str,
-        this: Option<Value>,
+        this: Option<Cow<'context, dyn Val>>,
         ptx: &'context Context<'context>,
         args: &'call [Expression],
     ) -> Self {
@@ -315,6 +316,7 @@ pub fn matches(
     }
 }
 
+use crate::common::value::Val;
 #[cfg(feature = "chrono")]
 pub use time::duration;
 #[cfg(feature = "chrono")]

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -538,6 +538,7 @@ mod tests {
             ("size of bytes", "size(b'foo') == 3"),
             ("size as a list method", "[1, 2, 3].size() == 3"),
             ("size as a string method", "'foobar'.size() == 6"),
+            ("size as a bytes method", "b'foobar'.size() == 6"),
         ]
         .iter()
         .for_each(assert_script);

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -919,6 +919,7 @@ mod tests {
         [
             ("string", "bytes('abc') == b'abc'"),
             ("bytes", "bytes('abc') == b'\\x61b\\x63'"),
+            ("bytes_to_bytes", "bytes(b'abc') == b'\\x61b\\x63'"),
         ]
         .iter()
         .for_each(assert_script);

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -8,6 +8,7 @@ mod macros;
 
 pub mod common;
 pub mod context;
+mod env;
 pub mod parser;
 
 pub use common::ast::IdedExpr;
@@ -26,6 +27,8 @@ mod resolvers;
 mod duration;
 #[cfg(feature = "chrono")]
 pub use ser::{Duration, Timestamp};
+
+pub use env::Env;
 
 mod ser;
 pub use ser::to_value;

--- a/cel/src/magic.rs
+++ b/cel/src/magic.rs
@@ -1,8 +1,7 @@
-use crate::common::ast::Expr;
 use crate::macros::{impl_conversions, impl_handler};
 use crate::objects::Opaque;
 use crate::resolvers::{AllArguments, Argument};
-use crate::{ExecutionError, Expression, FunctionContext, ResolveResult, Value};
+use crate::{ExecutionError, FunctionContext, ResolveResult, Value};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -190,21 +189,6 @@ where
 #[derive(Clone)]
 pub struct Identifier(pub Arc<String>);
 
-impl<'a, 'context, 'call> FromContext<'a, 'context, 'call> for Identifier {
-    fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
-    where
-        Self: Sized,
-    {
-        match &arg_expr_from_context(ctx).expr {
-            Expr::Ident(ident) => Ok(Identifier(ident.clone().into())),
-            expr => Err(ExecutionError::UnexpectedType {
-                got: format!("{expr:?}"),
-                want: "identifier".to_string(),
-            }),
-        }
-    }
-}
-
 impl From<&Identifier> for String {
     fn from(value: &Identifier) -> Self {
         value.0.to_string()
@@ -262,28 +246,6 @@ impl<'a, 'context, 'call> FromContext<'a, 'context, 'call> for Value {
     {
         arg_value_from_context(ctx)
     }
-}
-
-impl<'a, 'context, 'call> FromContext<'a, 'context, 'call> for Expression {
-    fn from_context(ctx: &'a mut FunctionContext<'context, 'call>) -> Result<Self, ExecutionError>
-    where
-        Self: Sized,
-    {
-        Ok(arg_expr_from_context(ctx).clone())
-    }
-}
-
-/// Returns the next argument specified by the context's `arg_idx` field as an expression
-/// (i.e. not resolved). Calling this multiple times will increment the `arg_idx` which will
-/// return subsequent arguments every time.
-///
-/// Calling this function when there are no more arguments will result in a panic. Since this
-/// function is only ever called within the context of a controlled macro that calls it once
-/// for each argument, this should never happen.
-fn arg_expr_from_context<'a>(ctx: &'a mut FunctionContext) -> &'a Expression {
-    let idx = ctx.arg_idx;
-    ctx.arg_idx += 1;
-    &ctx.args[idx]
 }
 
 /// Returns the next argument specified by the context's `arg_idx` field as after resolving

--- a/cel/src/magic.rs
+++ b/cel/src/magic.rs
@@ -150,7 +150,7 @@ where
         Self: Sized,
     {
         if let Some(ref this) = ctx.this {
-            Ok(This(T::from_value(this)?))
+            Ok(This(T::from_value(&this.as_ref().try_into()?)?))
         } else {
             let arg = arg_value_from_context(ctx)
                 .map_err(|_| ExecutionError::missing_argument_or_target())?;

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1301,19 +1301,26 @@ impl Value {
                         Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
                     }
                     Some(target) => {
-                        let qualified_func = match &target.expr {
-                            Expr::Ident(prefix) => {
-                                let qualified_name = format!("{prefix}.{}", &call.func_name);
-                                ctx.get_function(&qualified_name)
-                            }
-                            _ => None,
-                        };
                         let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
                             .args
                             .iter()
                             .map(|a| Value::resolve_val(a, ctx))
                             .collect();
                         let args = args?;
+                        let qualified_func = match &target.expr {
+                            Expr::Ident(prefix) => {
+                                let qualified_name = format!("{prefix}.{}", &call.func_name);
+                                let arg_types: Vec<Type<'_>> =
+                                    args.iter().map(|a| a.get_type()).collect();
+                                if let Some(op) =
+                                    ctx.env().find_overload(&qualified_name, &arg_types)
+                                {
+                                    return op(&args);
+                                }
+                                ctx.get_function(&qualified_name)
+                            }
+                            _ => None,
+                        };
                         let (target, func, args) = match qualified_func {
                             None => {
                                 let target = Value::resolve_val(target, ctx)?;

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1282,15 +1282,22 @@ impl Value {
                 }
                 match &call.target {
                     None => {
-                        let func = ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
-                            ExecutionError::UndeclaredReference(call.func_name.clone().into())
-                        })?;
+                        // TODO: Optimize for the 1 and 2 arg cases and avoid the Vec altogether
                         let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
                             .args
                             .iter()
                             .map(|a| Value::resolve_val(a, ctx))
                             .collect();
-                        let mut ctx = FunctionContext::new(&call.func_name, None, ctx, args?);
+                        let args = args?;
+                        let arg_types: Vec<Type<'_>> = args.iter().map(|a| a.get_type()).collect();
+                        if let Some(op) = ctx.env().find_overload(&call.func_name, &arg_types) {
+                            let ret = op(&args)?;
+                            return Ok(ret);
+                        }
+                        let func = ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
+                            ExecutionError::UndeclaredReference(call.func_name.clone().into())
+                        })?;
+                        let mut ctx = FunctionContext::new(&call.func_name, None, ctx, args);
                         let v = (func)(&mut ctx)?;
                         Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
                     }
@@ -1304,17 +1311,17 @@ impl Value {
                         };
                         match qualified_func {
                             None => {
+                                let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
+                                    .args
+                                    .iter()
+                                    .map(|a| Value::resolve_val(a, ctx))
+                                    .collect();
                                 let func =
                                     ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                                         ExecutionError::UndeclaredReference(
                                             call.func_name.clone().into(),
                                         )
                                     })?;
-                                let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
-                                    .args
-                                    .iter()
-                                    .map(|a| Value::resolve_val(a, ctx))
-                                    .collect();
                                 let mut ctx = FunctionContext::new(
                                     &call.func_name,
                                     Some(Value::resolve_val(target, ctx)?),

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1309,42 +1309,28 @@ impl Value {
                             }
                             _ => None,
                         };
-                        match qualified_func {
+                        let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
+                            .args
+                            .iter()
+                            .map(|a| Value::resolve_val(a, ctx))
+                            .collect();
+                        let (target, func) = match qualified_func {
                             None => {
-                                let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
-                                    .args
-                                    .iter()
-                                    .map(|a| Value::resolve_val(a, ctx))
-                                    .collect();
+                                let target = Value::resolve_val(target, ctx)?;
                                 let func =
                                     ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                                         ExecutionError::UndeclaredReference(
                                             call.func_name.clone().into(),
                                         )
                                     })?;
-                                let mut ctx = FunctionContext::new(
-                                    &call.func_name,
-                                    Some(Value::resolve_val(target, ctx)?),
-                                    ctx,
-                                    args?,
-                                );
-                                // todo fix this to _not_ use `Value`
-                                let v = (func)(&mut ctx)?;
-                                Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
+                                (Some(target), func)
                             }
-                            Some(func) => {
-                                let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
-                                    .args
-                                    .iter()
-                                    .map(|a| Value::resolve_val(a, ctx))
-                                    .collect();
-                                let mut ctx =
-                                    FunctionContext::new(&call.func_name, None, ctx, args?);
-                                // todo fix this to _not_ use `Value`
-                                let v = (func)(&mut ctx)?;
-                                Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
-                            }
-                        }
+                            Some(func) => (None, func),
+                        };
+                        let mut ctx = FunctionContext::new(&call.func_name, target, ctx, args?);
+                        // todo fix this to _not_ use `Value`
+                        let v = (func)(&mut ctx)?;
+                        Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
                     }
                 }
             }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -990,14 +990,14 @@ impl Value {
                                 let right = Value::resolve_val(&call.args[1], ctx)?
                                     .downcast_ref::<CelBool>()
                                     .map(|b| *b.inner());
-                                match (&left, right) {
+                                match (left, right) {
                                     (Ok(false), Some(right)) => {
                                         Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(right))))
                                     }
                                     (Err(_), Some(true)) => {
                                         Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(true))))
                                     }
-                                    (_, _) => Err(left.err().unwrap_or(NoSuchOverload)),
+                                    (left, _) => Err(left.err().unwrap_or(NoSuchOverload)),
                                 }
                             };
                         }
@@ -1009,14 +1009,14 @@ impl Value {
                                 let right = Value::resolve_val(&call.args[1], ctx)?
                                     .downcast_ref::<CelBool>()
                                     .map(|b| *b.inner());
-                                match (&left, right) {
+                                match (left, right) {
                                     (Ok(true), Some(right)) => {
                                         Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(right))))
                                     }
                                     (Err(_), Some(false)) => {
                                         Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(false))))
                                     }
-                                    (_, _) => Err(left.err().unwrap_or(NoSuchOverload)),
+                                    (left, _) => Err(left.err().unwrap_or(NoSuchOverload)),
                                 }
                             };
                         }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1314,30 +1314,28 @@ impl Value {
                             .map(|a| Value::resolve_val(a, ctx))
                             .collect();
                         let args = args?;
-                        let (target, func) = match qualified_func {
+                        let (target, func, args) = match qualified_func {
                             None => {
                                 let target = Value::resolve_val(target, ctx)?;
+                                let mut args = args;
+                                args.insert(0, target);
                                 let arg_types: Vec<Type<'_>> =
                                     args.iter().map(|a| a.get_type()).collect();
-                                if let Some(op) = ctx.env().find_member_overload(
-                                    &call.func_name,
-                                    target.get_type(),
-                                    &arg_types,
-                                ) {
-                                    let mut args = args;
-                                    args.insert(0, target);
+                                if let Some(op) =
+                                    ctx.env().find_member_overload(&call.func_name, &arg_types)
+                                {
                                     return op(&args);
                                 }
-                                println!("Miss");
+                                let target = args.remove(0);
                                 let func =
                                     ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                                         ExecutionError::UndeclaredReference(
                                             call.func_name.clone().into(),
                                         )
                                     })?;
-                                (Some(target), func)
+                                (Some(target), func, args)
                             }
-                            Some(func) => (None, func),
+                            Some(func) => (None, func, args),
                         };
                         let mut ctx = FunctionContext::new(&call.func_name, target, ctx, args);
                         // todo fix this to _not_ use `Value`

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1289,8 +1289,7 @@ impl Value {
                             .map(|a| Value::resolve_val(a, ctx))
                             .collect();
                         let args = args?;
-                        let arg_types: Vec<Type<'_>> = args.iter().map(|a| a.get_type()).collect();
-                        if let Some(op) = ctx.env().find_overload(&call.func_name, &arg_types) {
+                        if let Some(op) = ctx.env().find_overload(&call.func_name, &args) {
                             return op(args);
                         }
                         let func = ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
@@ -1310,11 +1309,7 @@ impl Value {
                         let qualified_func = match &target.expr {
                             Expr::Ident(prefix) => {
                                 let qualified_name = format!("{prefix}.{}", &call.func_name);
-                                let arg_types: Vec<Type<'_>> =
-                                    args.iter().map(|a| a.get_type()).collect();
-                                if let Some(op) =
-                                    ctx.env().find_overload(&qualified_name, &arg_types)
-                                {
+                                if let Some(op) = ctx.env().find_overload(&qualified_name, &args) {
                                     return op(args);
                                 }
                                 ctx.get_function(&qualified_name)
@@ -1326,10 +1321,8 @@ impl Value {
                                 let target = Value::resolve_val(target, ctx)?;
                                 let mut args = args;
                                 args.insert(0, target);
-                                let arg_types: Vec<Type<'_>> =
-                                    args.iter().map(|a| a.get_type()).collect();
                                 if let Some(op) =
-                                    ctx.env().find_member_overload(&call.func_name, &arg_types)
+                                    ctx.env().find_member_overload(&call.func_name, &args)
                                 {
                                     return op(args);
                                 }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1291,7 +1291,7 @@ impl Value {
                         let args = args?;
                         let arg_types: Vec<Type<'_>> = args.iter().map(|a| a.get_type()).collect();
                         if let Some(op) = ctx.env().find_overload(&call.func_name, &arg_types) {
-                            return op(&args);
+                            return op(args);
                         }
                         let func = ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                             ExecutionError::UndeclaredReference(call.func_name.clone().into())
@@ -1315,7 +1315,7 @@ impl Value {
                                 if let Some(op) =
                                     ctx.env().find_overload(&qualified_name, &arg_types)
                                 {
-                                    return op(&args);
+                                    return op(args);
                                 }
                                 ctx.get_function(&qualified_name)
                             }
@@ -1331,7 +1331,7 @@ impl Value {
                                 if let Some(op) =
                                     ctx.env().find_member_overload(&call.func_name, &arg_types)
                                 {
-                                    return op(&args);
+                                    return op(args);
                                 }
                                 let target = args.remove(0);
                                 let func =

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1308,7 +1308,7 @@ impl Value {
                                     })?;
                                 let mut ctx = FunctionContext::new(
                                     &call.func_name,
-                                    Some(Value::resolve_val(target, ctx)?.as_ref().try_into()?),
+                                    Some(Value::resolve_val(target, ctx)?),
                                     ctx,
                                     &call.args,
                                 );
@@ -2001,7 +2001,7 @@ mod tests {
     }
 
     mod opaque {
-        use crate::objects::{Map, Opaque, OptionalValue};
+        use crate::objects::{Map, Opaque, OpaqueVal, OptionalValue};
         use crate::parser::Parser;
         use crate::{Context, ExecutionError, FunctionContext, Program, Value};
         use serde::Serialize;
@@ -2029,9 +2029,11 @@ mod tests {
         #[test]
         fn test_opaque_fn() {
             pub fn my_fn(ftx: &FunctionContext) -> Result<Value, ExecutionError> {
-                if let Some(Value::Opaque(opaque)) = &ftx.this {
-                    if opaque.runtime_type_name() == "my_struct" {
+                if let Some(Some(opaque)) = ftx.this.as_ref().map(|v| v.downcast_ref::<OpaqueVal>())
+                {
+                    if opaque.0.runtime_type_name() == "my_struct" {
                         Ok(opaque
+                            .0
                             .deref()
                             .downcast_ref::<MyStruct>()
                             .unwrap()
@@ -2040,7 +2042,7 @@ mod tests {
                             .into())
                     } else {
                         Err(ExecutionError::UnexpectedType {
-                            got: opaque.runtime_type_name().to_string(),
+                            got: opaque.0.runtime_type_name().to_string(),
                             want: "my_struct".to_string(),
                         })
                     }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1291,8 +1291,7 @@ impl Value {
                         let args = args?;
                         let arg_types: Vec<Type<'_>> = args.iter().map(|a| a.get_type()).collect();
                         if let Some(op) = ctx.env().find_overload(&call.func_name, &arg_types) {
-                            let ret = op(&args)?;
-                            return Ok(ret);
+                            return op(&args);
                         }
                         let func = ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                             ExecutionError::UndeclaredReference(call.func_name.clone().into())
@@ -1314,9 +1313,22 @@ impl Value {
                             .iter()
                             .map(|a| Value::resolve_val(a, ctx))
                             .collect();
+                        let args = args?;
                         let (target, func) = match qualified_func {
                             None => {
                                 let target = Value::resolve_val(target, ctx)?;
+                                let arg_types: Vec<Type<'_>> =
+                                    args.iter().map(|a| a.get_type()).collect();
+                                if let Some(op) = ctx.env().find_member_overload(
+                                    &call.func_name,
+                                    target.get_type(),
+                                    &arg_types,
+                                ) {
+                                    let mut args = args;
+                                    args.insert(0, target);
+                                    return op(&args);
+                                }
+                                println!("Miss");
                                 let func =
                                     ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                                         ExecutionError::UndeclaredReference(
@@ -1327,7 +1339,7 @@ impl Value {
                             }
                             Some(func) => (None, func),
                         };
-                        let mut ctx = FunctionContext::new(&call.func_name, target, ctx, args?);
+                        let mut ctx = FunctionContext::new(&call.func_name, target, ctx, args);
                         // todo fix this to _not_ use `Value`
                         let v = (func)(&mut ctx)?;
                         Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1285,8 +1285,12 @@ impl Value {
                         let func = ctx.get_function(call.func_name.as_str()).ok_or_else(|| {
                             ExecutionError::UndeclaredReference(call.func_name.clone().into())
                         })?;
-                        // todo fix this to _not_ use `Value`
-                        let mut ctx = FunctionContext::new(&call.func_name, None, ctx, &call.args);
+                        let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
+                            .args
+                            .iter()
+                            .map(|a| Value::resolve_val(a, ctx))
+                            .collect();
+                        let mut ctx = FunctionContext::new(&call.func_name, None, ctx, args?);
                         let v = (func)(&mut ctx)?;
                         Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
                     }
@@ -1306,19 +1310,29 @@ impl Value {
                                             call.func_name.clone().into(),
                                         )
                                     })?;
+                                let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
+                                    .args
+                                    .iter()
+                                    .map(|a| Value::resolve_val(a, ctx))
+                                    .collect();
                                 let mut ctx = FunctionContext::new(
                                     &call.func_name,
                                     Some(Value::resolve_val(target, ctx)?),
                                     ctx,
-                                    &call.args,
+                                    args?,
                                 );
                                 // todo fix this to _not_ use `Value`
                                 let v = (func)(&mut ctx)?;
                                 Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
                             }
                             Some(func) => {
+                                let args: Result<Vec<Cow<dyn Val>>, ExecutionError> = call
+                                    .args
+                                    .iter()
+                                    .map(|a| Value::resolve_val(a, ctx))
+                                    .collect();
                                 let mut ctx =
-                                    FunctionContext::new(&call.func_name, None, ctx, &call.args);
+                                    FunctionContext::new(&call.func_name, None, ctx, args?);
                                 // todo fix this to _not_ use `Value`
                                 let v = (func)(&mut ctx)?;
                                 Ok(Cow::<dyn Val>::Owned(TryInto::<Box<dyn Val>>::try_into(v)?))
@@ -1957,34 +1971,6 @@ mod tests {
         for (expr, err) in cases {
             test_execution_error(expr, err);
         }
-    }
-
-    #[test]
-    fn test_function_identifier() {
-        fn with(
-            ftx: &crate::FunctionContext,
-            crate::extractors::This(this): crate::extractors::This<Value>,
-            ident: crate::extractors::Identifier,
-            expr: crate::parser::Expression,
-        ) -> crate::ResolveResult {
-            let mut ptx = ftx.ptx.new_inner_scope();
-            ptx.add_variable_from_value(&ident, this);
-            ptx.resolve(&expr)
-        }
-        let mut context = Context::default();
-        context.add_function("with", with);
-
-        let program = Program::compile("[1,2].with(a, a + a)").unwrap();
-        let value = program.execute(&context);
-        assert_eq!(
-            value,
-            Ok(Value::List(Arc::new(vec![
-                Value::Int(1),
-                Value::Int(2),
-                Value::Int(1),
-                Value::Int(2)
-            ])))
-        );
     }
 
     #[test]

--- a/cel/src/resolvers.rs
+++ b/cel/src/resolvers.rs
@@ -37,7 +37,7 @@ impl Resolver for Argument {
             .args
             .get(index)
             .ok_or_else(|| ExecutionError::invalid_argument_count(index + 1, ctx.args.len()))?;
-        Value::resolve(arg, ctx.ptx)
+        arg.as_ref().try_into()
     }
 }
 
@@ -54,7 +54,7 @@ impl Resolver for AllArguments {
     fn resolve(&self, ctx: &FunctionContext) -> ResolveResult {
         let mut args = Vec::with_capacity(ctx.args.len());
         for arg in ctx.args.iter() {
-            args.push(Value::resolve(arg, ctx.ptx)?);
+            args.push(arg.as_ref().try_into()?);
         }
         Ok(Value::List(args.into()))
     }


### PR DESCRIPTION
This is how I was thinking of going about overloads. Sharing this already to gather some feedback on "the plan". 
I can then port all `stdlib` functions we have to this new approach. 

Later, I think we should be able to provide a macro to provide the sugar coating for users to be able to easily add overloads. In the meantime, I'd leave `Context::functions` untouched and remain the easy way for users to register those. I tried to do both at once, but `FunctionContext` et al (e.g. all the "magic" & other macros) are a can of worms I'd rather not open right now. So all the `Context::functions` remain as is and keep on using `Value`. 