### PR TITLE
The stdlib uses overloads, over `Context::functions`

### DIFF
--- a/cel/src/common/types/double.rs
+++ b/cel/src/common/types/double.rs
@@ -1,6 +1,6 @@
 use crate::common::traits::{Adder, Comparer, Divider, Multiplier, Negator, Subtractor};
-use crate::common::types::{CelInt, CelUInt, Type};
-use crate::common::value::Val;
+use crate::common::types::{CelInt, CelString, CelUInt, Type};
+use crate::common::value::{Downcast, Val};
 use crate::{ExecutionError, Value};
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -184,6 +184,62 @@ impl<'a> TryFrom<&'a dyn Val> for &'a f64 {
         }
         Err(value)
     }
+}
+
+fn double<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let arg = args.remove(0).into_owned();
+    let ret: Result<Box<Double>, Box<dyn Val>> = match arg.get_type() {
+        super::DOUBLE_TYPE => arg.downcast::<Double>(),
+        super::INT_TYPE => arg
+            .downcast::<CelInt>()
+            .map(|arg| Box::new(Double::from(*arg.inner() as f64))),
+        super::UINT_TYPE => arg
+            .downcast::<CelUInt>()
+            .map(|arg| Box::new(Double::from(*arg.inner() as f64))),
+        super::STRING_TYPE => match arg.downcast::<CelString>() {
+            Err(arg) => Err(arg),
+            Ok(arg) => match arg.inner().parse::<f64>() {
+                Ok(arg) => Ok(Box::new(Double::from(arg))),
+                Err(e) => {
+                    return Err(ExecutionError::FunctionError {
+                        function: "double".to_owned(),
+                        message: format!("string parse error: {e}"),
+                    })
+                }
+            },
+        },
+        _ => Err(arg),
+    };
+
+    match ret {
+        Ok(ret) => Ok(Cow::<dyn Val>::Owned(ret)),
+        Err(arg) => Err(ExecutionError::FunctionError {
+            function: "double".to_owned(),
+            message: format!("cannot convert {arg:?} to double"),
+        }),
+    }
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "double",
+        "double_to_double",
+        vec![super::DOUBLE_TYPE],
+        double,
+    )
+    .expect("Must be unique id");
+    env.add_overload("double", "int64_to_double", vec![super::INT_TYPE], double)
+        .expect("Must be unique id");
+    env.add_overload("double", "uint64_to_double", vec![super::UINT_TYPE], double)
+        .expect("Must be unique id");
+    env.add_overload(
+        "double",
+        "string_to_double",
+        vec![super::STRING_TYPE],
+        double,
+    )
+    .expect("Must be unique id");
 }
 
 #[cfg(test)]

--- a/cel/src/common/types/duration.rs
+++ b/cel/src/common/types/duration.rs
@@ -1,5 +1,5 @@
 use crate::common::traits::{Adder, Comparer, Subtractor};
-use crate::common::types::Type;
+use crate::common::types::{CelInt, CelString, Type};
 use crate::common::value::Val;
 use crate::{ExecutionError, Value};
 use std::borrow::Cow;
@@ -131,4 +131,76 @@ impl<'a> TryFrom<&'a dyn Val> for &'a chrono::Duration {
     }
 }
 
-pub(crate) fn stdlib(_env: &mut crate::Env<'_>) {}
+fn millis<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::DURATION_TYPE, |ts: &Duration| {
+        Ok(Box::new(CelInt::from(ts.inner().num_milliseconds())))
+    })
+}
+
+fn seconds<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::DURATION_TYPE, |ts: &Duration| {
+        Ok(Box::new(CelInt::from(ts.inner().num_seconds())))
+    })
+}
+
+fn minutes<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::DURATION_TYPE, |ts: &Duration| {
+        Ok(Box::new(CelInt::from(ts.inner().num_minutes())))
+    })
+}
+
+fn hours<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::DURATION_TYPE, |ts: &Duration| {
+        Ok(Box::new(CelInt::from(ts.inner().num_hours())))
+    })
+}
+
+fn duration<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::STRING_TYPE, |value: &CelString| {
+        let (_, duration) = crate::duration::parse_duration(value.inner())
+            .map_err(|e| ExecutionError::function_error("duration", e.to_string()))?;
+        Ok(Box::new(Duration::from(duration)))
+    })
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "duration",
+        "string_to_duration",
+        vec![super::STRING_TYPE],
+        duration,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getHours",
+        "duration_to_hours",
+        super::DURATION_TYPE,
+        Vec::default(),
+        hours,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getMinutes",
+        "duration_to_minutes",
+        super::DURATION_TYPE,
+        Vec::default(),
+        minutes,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getSeconds",
+        "duration_to_seconds",
+        super::DURATION_TYPE,
+        Vec::default(),
+        seconds,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getMilliseconds",
+        "duration_to_millis",
+        super::DURATION_TYPE,
+        Vec::default(),
+        millis,
+    )
+    .expect("Must be unique");
+}

--- a/cel/src/common/types/duration.rs
+++ b/cel/src/common/types/duration.rs
@@ -130,3 +130,5 @@ impl<'a> TryFrom<&'a dyn Val> for &'a chrono::Duration {
         Err(value)
     }
 }
+
+pub(crate) fn stdlib(_env: &mut crate::Env<'_>) {}

--- a/cel/src/common/types/duration.rs
+++ b/cel/src/common/types/duration.rs
@@ -171,6 +171,13 @@ pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
         duration,
     )
     .expect("Must be unique");
+    env.add_overload(
+        "duration",
+        "duration_to_duration",
+        vec![super::DURATION_TYPE],
+        super::noop,
+    )
+    .expect("Must be unique");
     env.add_member_overload(
         "getHours",
         "duration_to_hours",

--- a/cel/src/common/types/int.rs
+++ b/cel/src/common/types/int.rs
@@ -1,7 +1,7 @@
 use crate::common::traits::Negator;
 use crate::common::traits::{self, Comparer};
-use crate::common::types::{CelDouble, CelUInt, Type};
-use crate::common::value::Val;
+use crate::common::types::{CelDouble, CelString, CelUInt, Type};
+use crate::common::value::{Downcast, Val};
 use crate::ExecutionError;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -214,6 +214,52 @@ impl<'a> TryFrom<&'a dyn Val> for &'a i64 {
         }
         Err(value)
     }
+}
+
+fn int<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let arg = args.remove(0).into_owned();
+    let ret: Result<Box<Int>, Box<dyn Val>> = match arg.get_type() {
+        super::INT_TYPE => arg.downcast::<Int>(),
+        super::UINT_TYPE => arg
+            .downcast::<CelUInt>()
+            .map(|arg| Box::new(Int::from(*arg.inner() as i64))),
+        super::DOUBLE_TYPE => arg
+            .downcast::<CelDouble>()
+            .map(|arg| Box::new(Int::from(*arg.inner() as i64))),
+        super::STRING_TYPE => match arg.downcast::<CelString>() {
+            Err(arg) => Err(arg),
+            Ok(arg) => match arg.inner().parse::<i64>() {
+                Ok(arg) => Ok(Box::new(Int::from(arg))),
+                Err(e) => {
+                    return Err(ExecutionError::FunctionError {
+                        function: "int".to_owned(),
+                        message: format!("string parse error: {e}"),
+                    })
+                }
+            },
+        },
+        _ => Err(arg),
+    };
+
+    match ret {
+        Ok(ret) => Ok(Cow::<dyn Val>::Owned(ret)),
+        Err(arg) => Err(ExecutionError::FunctionError {
+            function: "double".to_owned(),
+            message: format!("cannot convert {arg:?} to double"),
+        }),
+    }
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload("int", "int64_to_int64", vec![super::INT_TYPE], int)
+        .expect("Must be unique id");
+    env.add_overload("int", "uint64_to_int64", vec![super::UINT_TYPE], int)
+        .expect("Must be unique id");
+    env.add_overload("int", "double_to_int64", vec![super::DOUBLE_TYPE], int)
+        .expect("Must be unique id");
+    env.add_overload("int", "string_to_int64", vec![super::STRING_TYPE], int)
+        .expect("Must be unique id");
 }
 
 #[cfg(test)]

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 
 pub(crate) mod bool;
 pub(crate) mod bytes;
-mod double;
+pub(crate) mod double;
 #[cfg(feature = "chrono")]
 pub(crate) mod duration;
 mod int;

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -16,7 +16,7 @@ mod optional;
 pub(crate) mod string;
 #[cfg(feature = "chrono")]
 pub(crate) mod timestamp;
-mod uint;
+pub(crate) mod uint;
 
 use crate::common::traits::TraitSet;
 use crate::common::value::Val;

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -1,5 +1,5 @@
-use crate::ExecutionError;
 use crate::common::traits;
+use crate::ExecutionError;
 use std::any::Any;
 use std::borrow::Cow;
 
@@ -7,7 +7,7 @@ pub(crate) mod bool;
 pub(crate) mod bytes;
 mod double;
 #[cfg(feature = "chrono")]
-mod duration;
+pub(crate) mod duration;
 mod int;
 pub(crate) mod list;
 pub(crate) mod map;
@@ -15,7 +15,7 @@ mod null;
 mod optional;
 pub(crate) mod string;
 #[cfg(feature = "chrono")]
-mod timestamp;
+pub(crate) mod timestamp;
 mod uint;
 
 use crate::common::traits::TraitSet;
@@ -264,7 +264,23 @@ fn cast_boxed<T: Val>(value: Box<dyn Val>) -> Result<Box<T>, Box<dyn Val>> {
     Err(value)
 }
 
+type UnaryFn<A> = fn(&A) -> Result<Box<dyn Val>, ExecutionError>;
 type BinaryFn<A, B> = fn(&A, &B) -> Result<Box<dyn Val>, ExecutionError>;
+
+fn unary_fn<'a, A: Val>(
+    args: Vec<Cow<'a, dyn Val>>,
+    type_a: Type<'_>,
+    func: UnaryFn<A>,
+) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let arg = &args[0];
+    match arg.downcast_ref::<A>() {
+        None => Err(ExecutionError::UnexpectedType {
+            got: arg.get_type().name().to_string(),
+            want: type_a.name().to_string(),
+        }),
+        Some(arg) => Ok(Cow::<dyn Val>::Owned(func(arg)?)),
+    }
+}
 
 fn binary_fn<'a, A: Val, B: Val>(
     args: Vec<Cow<'a, dyn Val>>,
@@ -288,7 +304,6 @@ fn binary_fn<'a, A: Val, B: Val>(
         },
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -305,6 +305,12 @@ fn binary_fn<'a, A: Val, B: Val>(
     }
 }
 
+fn noop<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let ts = args.remove(0);
+    Ok(ts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod bytes;
 pub(crate) mod double;
 #[cfg(feature = "chrono")]
 pub(crate) mod duration;
-mod int;
+pub(crate) mod int;
 pub(crate) mod list;
 pub(crate) mod map;
 mod null;

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -1,5 +1,7 @@
+use crate::ExecutionError;
 use crate::common::traits;
 use std::any::Any;
+use std::borrow::Cow;
 
 pub(crate) mod bool;
 pub(crate) mod bytes;
@@ -261,6 +263,32 @@ fn cast_boxed<T: Val>(value: Box<dyn Val>) -> Result<Box<T>, Box<dyn Val>> {
     }
     Err(value)
 }
+
+type BinaryFn<A, B> = fn(&A, &B) -> Result<Box<dyn Val>, ExecutionError>;
+
+fn binary_fn<'a, A: Val, B: Val>(
+    args: Vec<Cow<'a, dyn Val>>,
+    type_a: Type<'_>,
+    type_b: Type<'_>,
+    func: BinaryFn<A, B>,
+) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let arg1 = &args[0];
+    let arg2 = &args[1];
+    match arg1.downcast_ref::<A>() {
+        None => Err(ExecutionError::UnexpectedType {
+            got: arg1.get_type().name().to_string(),
+            want: type_a.name().to_string(),
+        }),
+        Some(arg1) => match arg2.downcast_ref::<B>() {
+            None => Err(ExecutionError::UnexpectedType {
+                got: arg2.get_type().name().to_string(),
+                want: type_b.name().to_string(),
+            }),
+            Some(arg2) => Ok(Cow::<dyn Val>::Owned(func(arg1, arg2)?)),
+        },
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -167,6 +167,22 @@ fn starts_with_string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val
     )
 }
 
+#[cfg(feature = "regex")]
+fn matches<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::binary_fn(
+        args,
+        super::STRING_TYPE,
+        super::STRING_TYPE,
+        |this: &String, regex: &String| match regex::Regex::new(regex.inner()) {
+            Ok(re) => Ok(Box::new(CelBool::from(re.is_match(this.inner())))),
+            Err(err) => Err(ExecutionError::FunctionError {
+                function: "matches".to_string(),
+                message: format!("'{}' not a valid regex:\n{err}", regex.inner()),
+            }),
+        },
+    )
+}
+
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
     env.add_member_overload(
         "contains",
@@ -205,6 +221,15 @@ pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
         super::STRING_TYPE,
         vec![super::STRING_TYPE],
         starts_with_string,
+    )
+    .expect("Must be unique id");
+    #[cfg(feature = "regex")]
+    env.add_member_overload(
+        "matches",
+        "matches",
+        super::STRING_TYPE,
+        vec![super::STRING_TYPE],
+        matches,
     )
     .expect("Must be unique id");
 }

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -1,6 +1,8 @@
 use crate::common::traits::{self, Adder, Comparer, Sizer};
-use crate::common::types::{CelBool, CelInt, Type};
-use crate::common::value::Val;
+use crate::common::types::{CelBool, CelBytes, CelDouble, CelInt, CelUInt, Type};
+#[cfg(feature = "chrono")]
+use crate::common::types::{CelDuration, CelTimestamp};
+use crate::common::value::{Downcast, Val};
 use crate::ExecutionError;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -183,7 +185,84 @@ fn matches<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Executio
     )
 }
 
+fn string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let arg = args.remove(0).into_owned();
+    let ret: Result<Box<String>, Box<dyn Val>> = match arg.get_type() {
+        super::STRING_TYPE => arg.downcast::<String>(),
+        super::INT_TYPE => arg
+            .downcast::<CelInt>()
+            .map(|arg| Box::new(String::from(arg.to_string()))),
+        super::UINT_TYPE => arg
+            .downcast::<CelUInt>()
+            .map(|arg| Box::new(String::from(arg.to_string()))),
+        super::DOUBLE_TYPE => arg
+            .downcast::<CelDouble>()
+            .map(|arg| Box::new(String::from(arg.to_string()))),
+        super::BYTES_TYPE => arg.downcast::<CelBytes>().map(|arg| {
+            Box::new(String::from(
+                StdString::from_utf8_lossy(arg.inner()).as_ref(),
+            ))
+        }),
+        #[cfg(feature = "chrono")]
+        super::TIMESTAMP_TYPE => arg
+            .downcast::<CelTimestamp>()
+            .map(|ts| Box::new(String::from(ts.inner().to_rfc3339()))),
+        #[cfg(feature = "chrono")]
+        super::DURATION_TYPE => arg
+            .downcast::<CelDuration>()
+            .map(|arg| Box::new(String::from(crate::duration::format_duration(arg.inner())))),
+        _ => Err(arg),
+    };
+    match ret {
+        Ok(ret) => Ok(Cow::<dyn Val>::Owned(ret)),
+        Err(arg) => Err(ExecutionError::FunctionError {
+            function: "string".to_owned(),
+            message: format!("cannot convert {arg:?} to string"),
+        }),
+    }
+}
+
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "string",
+        "string_to_string",
+        vec![super::STRING_TYPE],
+        string,
+    )
+    .expect("Must be unique id");
+    env.add_overload("string", "int64_to_string", vec![super::INT_TYPE], string)
+        .expect("Must be unique id");
+    env.add_overload("string", "uint64_to_string", vec![super::UINT_TYPE], string)
+        .expect("Must be unique id");
+    env.add_overload(
+        "string",
+        "double_to_string",
+        vec![super::DOUBLE_TYPE],
+        string,
+    )
+    .expect("Must be unique id");
+    env.add_overload("string", "bytes_to_string", vec![super::BYTES_TYPE], string)
+        .expect("Must be unique id");
+
+    #[cfg(feature = "chrono")]
+    {
+        env.add_overload(
+            "string",
+            "timestamp_to_string",
+            vec![super::TIMESTAMP_TYPE],
+            string,
+        )
+        .expect("Must be unique id");
+        env.add_overload(
+            "string",
+            "duration_to_string",
+            vec![super::DURATION_TYPE],
+            string,
+        )
+        .expect("Must be unique id");
+    }
+
     env.add_member_overload(
         "contains",
         "contains_string",

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -145,6 +145,46 @@ fn string_contains<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, 
     }
 }
 
+fn ends_with_string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let target = &args[0];
+    let arg = &args[1];
+    match target.downcast_ref::<String>() {
+        None => Err(ExecutionError::UnexpectedType {
+            got: target.get_type().name().to_string(),
+            want: super::STRING_TYPE.name().to_string(),
+        }),
+        Some(s) => match arg.downcast_ref::<String>() {
+            None => Err(ExecutionError::UnexpectedType {
+                got: arg.get_type().name().to_string(),
+                want: super::STRING_TYPE.name().to_string(),
+            }),
+            Some(needle) => Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(
+                s.ends_with(needle.inner()),
+            )))),
+        },
+    }
+}
+
+fn starts_with_string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let target = &args[0];
+    let arg = &args[1];
+    match target.downcast_ref::<String>() {
+        None => Err(ExecutionError::UnexpectedType {
+            got: target.get_type().name().to_string(),
+            want: super::STRING_TYPE.name().to_string(),
+        }),
+        Some(s) => match arg.downcast_ref::<String>() {
+            None => Err(ExecutionError::UnexpectedType {
+                got: arg.get_type().name().to_string(),
+                want: super::STRING_TYPE.name().to_string(),
+            }),
+            Some(needle) => Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(
+                s.starts_with(needle.inner()),
+            )))),
+        },
+    }
+}
+
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
     env.add_member_overload(
         "contains",
@@ -152,6 +192,14 @@ pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
         super::STRING_TYPE,
         vec![super::STRING_TYPE],
         string_contains,
+    )
+    .expect("Must be unique id");
+    env.add_member_overload(
+        "endsWith",
+        "ends_with_string",
+        super::STRING_TYPE,
+        vec![super::STRING_TYPE],
+        ends_with_string,
     )
     .expect("Must be unique id");
     env.add_overload(
@@ -167,6 +215,14 @@ pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
         super::STRING_TYPE,
         vec![],
         traits::adapter::sizer_size,
+    )
+    .expect("Must be unique id");
+    env.add_member_overload(
+        "startsWith",
+        "starts_with_string",
+        super::STRING_TYPE,
+        vec![super::STRING_TYPE],
+        starts_with_string,
     )
     .expect("Must be unique id");
 }

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -146,43 +146,25 @@ fn string_contains<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, 
 }
 
 fn ends_with_string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-    let target = &args[0];
-    let arg = &args[1];
-    match target.downcast_ref::<String>() {
-        None => Err(ExecutionError::UnexpectedType {
-            got: target.get_type().name().to_string(),
-            want: super::STRING_TYPE.name().to_string(),
-        }),
-        Some(s) => match arg.downcast_ref::<String>() {
-            None => Err(ExecutionError::UnexpectedType {
-                got: arg.get_type().name().to_string(),
-                want: super::STRING_TYPE.name().to_string(),
-            }),
-            Some(needle) => Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(
-                s.ends_with(needle.inner()),
-            )))),
+    super::binary_fn(
+        args,
+        super::STRING_TYPE,
+        super::STRING_TYPE,
+        |target: &String, needle: &String| {
+            Ok(Box::new(CelBool::from(target.ends_with(needle.inner()))))
         },
-    }
+    )
 }
 
 fn starts_with_string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-    let target = &args[0];
-    let arg = &args[1];
-    match target.downcast_ref::<String>() {
-        None => Err(ExecutionError::UnexpectedType {
-            got: target.get_type().name().to_string(),
-            want: super::STRING_TYPE.name().to_string(),
-        }),
-        Some(s) => match arg.downcast_ref::<String>() {
-            None => Err(ExecutionError::UnexpectedType {
-                got: arg.get_type().name().to_string(),
-                want: super::STRING_TYPE.name().to_string(),
-            }),
-            Some(needle) => Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(
-                s.starts_with(needle.inner()),
-            )))),
+    super::binary_fn(
+        args,
+        super::STRING_TYPE,
+        super::STRING_TYPE,
+        |target: &String, needle: &String| {
+            Ok(Box::new(CelBool::from(target.starts_with(needle.inner()))))
         },
-    }
+    )
 }
 
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -1,5 +1,5 @@
 use crate::common::traits::{self, Adder, Comparer, Sizer};
-use crate::common::types::{CelInt, Type};
+use crate::common::types::{CelBool, CelInt, Type};
 use crate::common::value::Val;
 use crate::ExecutionError;
 use std::borrow::Cow;
@@ -125,7 +125,35 @@ impl<'a> TryFrom<&'a dyn Val> for &'a str {
     }
 }
 
+fn string_contains<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let target = &args[0];
+    let arg = &args[1];
+    match target.downcast_ref::<String>() {
+        None => Err(ExecutionError::UnexpectedType {
+            got: target.get_type().name().to_string(),
+            want: super::STRING_TYPE.name().to_string(),
+        }),
+        Some(s) => match arg.downcast_ref::<String>() {
+            None => Err(ExecutionError::UnexpectedType {
+                got: arg.get_type().name().to_string(),
+                want: super::STRING_TYPE.name().to_string(),
+            }),
+            Some(needle) => Ok(Cow::<dyn Val>::Owned(Box::new(CelBool::from(
+                s.contains(needle.inner()),
+            )))),
+        },
+    }
+}
+
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_member_overload(
+        "contains",
+        "contains_string",
+        super::STRING_TYPE,
+        vec![super::STRING_TYPE],
+        string_contains,
+    )
+    .expect("Must be unique id");
     env.add_overload(
         "size",
         "size_string",

--- a/cel/src/common/types/timestamp.rs
+++ b/cel/src/common/types/timestamp.rs
@@ -249,12 +249,25 @@ fn timestamp<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Execut
     })
 }
 
+fn noop<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let ts = args.remove(0);
+    Ok(ts)
+}
+
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
     env.add_overload(
         "timestamp",
         "string_to_timestamp",
         vec![super::STRING_TYPE],
         timestamp,
+    )
+    .expect("Must be unique");
+    env.add_overload(
+        "timestamp",
+        "timestamp_to_timestamp",
+        vec![super::TIMESTAMP_TYPE],
+        noop,
     )
     .expect("Must be unique");
     env.add_member_overload(

--- a/cel/src/common/types/timestamp.rs
+++ b/cel/src/common/types/timestamp.rs
@@ -1,8 +1,9 @@
 use crate::common::traits::{Adder, Comparer, Subtractor};
-use crate::common::types::{CelDuration, Type};
+use crate::common::types::{CelDuration, CelInt, CelString, Type};
 use crate::common::value::Val;
 use crate::{ExecutionError, Value};
-use chrono::TimeZone;
+use chrono::{Datelike, Days, Months};
+use chrono::{TimeZone, Timelike};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::ops::{Add, Sub};
@@ -165,4 +166,175 @@ impl<'a> TryFrom<&'a dyn Val> for &'a chrono::DateTime<chrono::FixedOffset> {
         }
         Err(value)
     }
+}
+
+fn millis<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(
+            ts.inner().timestamp_subsec_millis() as i64
+        )))
+    })
+}
+
+fn seconds<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(ts.inner().second() as i64)))
+    })
+}
+
+fn minutes<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(ts.inner().minute() as i64)))
+    })
+}
+
+fn hours<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(ts.inner().hour() as i64)))
+    })
+}
+
+fn day_of_week<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(
+            ts.inner().weekday().num_days_from_sunday() as i64,
+        )))
+    })
+}
+
+fn date<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(ts.inner().day() as i64)))
+    })
+}
+
+fn day_of_month<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(ts.inner().day0() as i64)))
+    })
+}
+
+fn day_of_year<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        let year = ts
+            .inner()
+            .checked_sub_days(Days::new(ts.inner().day0() as u64))
+            .unwrap()
+            .checked_sub_months(Months::new(ts.inner().month0()))
+            .unwrap();
+        Ok(Box::new(CelInt::from(
+            ts.inner().signed_duration_since(year).num_days(),
+        )))
+    })
+}
+
+fn month<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(ts.inner().month0() as i64)))
+    })
+}
+
+fn full_year<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::TIMESTAMP_TYPE, |ts: &Timestamp| {
+        Ok(Box::new(CelInt::from(ts.inner().year() as i64)))
+    })
+}
+
+fn timestamp<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, super::STRING_TYPE, |value: &CelString| {
+        Ok(Box::new(Timestamp::from(
+            chrono::DateTime::parse_from_rfc3339(value.inner())
+                .map_err(|e| ExecutionError::function_error("timestamp", e.to_string().as_str()))?,
+        )))
+    })
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload(
+        "timestamp",
+        "string_to_timestamp",
+        vec![super::STRING_TYPE],
+        timestamp,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getFullYear",
+        "timestamp_to_year",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        full_year,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getMonth",
+        "timestamp_to_month",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        month,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getDayOfYear",
+        "timestamp_to_day_of_year",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        day_of_year,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getDayOfMonth",
+        "timestamp_to_day_of_month",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        day_of_month,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getDate",
+        "timestamp_to_day_of_month_1_based",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        date,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getDayOfWeek",
+        "timestamp_to_day_of_week",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        day_of_week,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getHours",
+        "timestamp_to_hours",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        hours,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getMinutes",
+        "timestamp_to_minutes",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        minutes,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getSeconds",
+        "timestamp_to_seconds",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        seconds,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "getMilliseconds",
+        "timestamp_to_millis",
+        super::TIMESTAMP_TYPE,
+        Vec::default(),
+        millis,
+    )
+    .expect("Must be unique");
 }

--- a/cel/src/common/types/timestamp.rs
+++ b/cel/src/common/types/timestamp.rs
@@ -249,12 +249,6 @@ fn timestamp<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Execut
     })
 }
 
-fn noop<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-    let mut args = args;
-    let ts = args.remove(0);
-    Ok(ts)
-}
-
 pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
     env.add_overload(
         "timestamp",
@@ -267,7 +261,7 @@ pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
         "timestamp",
         "timestamp_to_timestamp",
         vec![super::TIMESTAMP_TYPE],
-        noop,
+        super::noop,
     )
     .expect("Must be unique");
     env.add_member_overload(

--- a/cel/src/common/types/uint.rs
+++ b/cel/src/common/types/uint.rs
@@ -1,6 +1,6 @@
 use crate::common::traits::{Adder, Comparer, Divider, Modder, Multiplier, Subtractor};
-use crate::common::types::{CelDouble, CelInt, Type};
-use crate::common::value::Val;
+use crate::common::types::{CelDouble, CelInt, CelString, Type};
+use crate::common::value::{Downcast, Val};
 use crate::{ExecutionError, Value};
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -235,6 +235,52 @@ impl<'a> TryFrom<&'a dyn Val> for &'a u64 {
         }
         Err(value)
     }
+}
+
+fn uint<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let arg = args.remove(0).into_owned();
+    let ret: Result<Box<UInt>, Box<dyn Val>> = match arg.get_type() {
+        super::UINT_TYPE => arg.downcast::<UInt>(),
+        super::INT_TYPE => arg
+            .downcast::<CelInt>()
+            .map(|arg| Box::new(UInt::from(*arg.inner() as u64))),
+        super::DOUBLE_TYPE => arg
+            .downcast::<CelDouble>()
+            .map(|arg| Box::new(UInt::from(*arg.inner() as u64))),
+        super::STRING_TYPE => match arg.downcast::<CelString>() {
+            Err(arg) => Err(arg),
+            Ok(arg) => match arg.inner().parse::<u64>() {
+                Ok(arg) => Ok(Box::new(UInt::from(arg))),
+                Err(e) => {
+                    return Err(ExecutionError::FunctionError {
+                        function: "int".to_owned(),
+                        message: format!("string parse error: {e}"),
+                    })
+                }
+            },
+        },
+        _ => Err(arg),
+    };
+
+    match ret {
+        Ok(ret) => Ok(Cow::<dyn Val>::Owned(ret)),
+        Err(arg) => Err(ExecutionError::FunctionError {
+            function: "double".to_owned(),
+            message: format!("cannot convert {arg:?} to double"),
+        }),
+    }
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+    env.add_overload("uint", "uint64_to_uint64", vec![super::UINT_TYPE], uint)
+        .expect("Must be unique id");
+    env.add_overload("uint", "int64_to_uint64", vec![super::INT_TYPE], uint)
+        .expect("Must be unique id");
+    env.add_overload("uint", "double_to_uint64", vec![super::DOUBLE_TYPE], uint)
+        .expect("Must be unique id");
+    env.add_overload("uint", "string_to_uint64", vec![super::STRING_TYPE], uint)
+        .expect("Must be unique id");
 }
 
 #[cfg(test)]

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -234,8 +234,6 @@ impl Default for Context<'_> {
 
         ctx.add_function("max", functions::max);
         ctx.add_function("min", functions::min);
-        ctx.add_function("startsWith", functions::starts_with);
-        ctx.add_function("endsWith", functions::ends_with);
         ctx.add_function("string", functions::string);
         ctx.add_function("double", functions::double);
         ctx.add_function("int", functions::int);

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -255,13 +255,7 @@ impl Default for Context<'_> {
         #[cfg(feature = "chrono")]
         {
             ctx.add_function("duration", functions::duration);
-            ctx.add_function("timestamp", functions::timestamp);
-            ctx.add_function("getFullYear", functions::time::timestamp_year);
-            ctx.add_function("getMonth", functions::time::timestamp_month);
-            ctx.add_function("getDayOfYear", functions::time::timestamp_year_day);
-            ctx.add_function("getDayOfMonth", functions::time::timestamp_month_day);
-            ctx.add_function("getDate", functions::time::timestamp_date);
-            ctx.add_function("getDayOfWeek", functions::time::timestamp_weekday);
+
             ctx.add_function("getHours", functions::time::get_hours);
             ctx.add_function("getMinutes", functions::time::get_minutes);
             ctx.add_function("getSeconds", functions::time::get_seconds);

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -232,7 +232,6 @@ impl Default for Context<'_> {
             resolver: None,
         };
 
-        ctx.add_function("int", functions::int);
         ctx.add_function("uint", functions::uint);
 
         // Optional

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -232,8 +232,6 @@ impl Default for Context<'_> {
             resolver: None,
         };
 
-        ctx.add_function("uint", functions::uint);
-
         // Optional
         ctx.add_function("optional.none", functions::optional_none);
         ctx.add_function("optional.of", functions::optional_of);

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -232,7 +232,6 @@ impl Default for Context<'_> {
             resolver: None,
         };
 
-        ctx.add_function("double", functions::double);
         ctx.add_function("int", functions::int);
         ctx.add_function("uint", functions::uint);
 

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -232,7 +232,6 @@ impl Default for Context<'_> {
             resolver: None,
         };
 
-        ctx.add_function("contains", functions::contains);
         ctx.add_function("max", functions::max);
         ctx.add_function("min", functions::min);
         ctx.add_function("startsWith", functions::starts_with);

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -252,16 +252,6 @@ impl Default for Context<'_> {
         #[cfg(feature = "regex")]
         ctx.add_function("matches", functions::matches);
 
-        #[cfg(feature = "chrono")]
-        {
-            ctx.add_function("duration", functions::duration);
-
-            ctx.add_function("getHours", functions::time::get_hours);
-            ctx.add_function("getMinutes", functions::time::get_minutes);
-            ctx.add_function("getSeconds", functions::time::get_seconds);
-            ctx.add_function("getMilliseconds", functions::time::get_milliseconds);
-        }
-
         ctx
     }
 }

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -232,12 +232,15 @@ impl Default for Context<'_> {
             resolver: None,
         };
 
-        ctx.add_function("max", functions::max);
-        ctx.add_function("min", functions::min);
         ctx.add_function("string", functions::string);
         ctx.add_function("double", functions::double);
         ctx.add_function("int", functions::int);
         ctx.add_function("uint", functions::uint);
+
+        #[cfg(feature = "regex")]
+        ctx.add_function("matches", functions::matches);
+
+        // Optional
         ctx.add_function("optional.none", functions::optional_none);
         ctx.add_function("optional.of", functions::optional_of);
         ctx.add_function(
@@ -248,10 +251,6 @@ impl Default for Context<'_> {
         ctx.add_function("hasValue", functions::optional_has_value);
         ctx.add_function("or", functions::optional_or_optional);
         ctx.add_function("orValue", functions::optional_or_value);
-
-        #[cfg(feature = "regex")]
-        ctx.add_function("matches", functions::matches);
-
         ctx
     }
 }

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -237,9 +237,6 @@ impl Default for Context<'_> {
         ctx.add_function("int", functions::int);
         ctx.add_function("uint", functions::uint);
 
-        #[cfg(feature = "regex")]
-        ctx.add_function("matches", functions::matches);
-
         // Optional
         ctx.add_function("optional.none", functions::optional_none);
         ctx.add_function("optional.of", functions::optional_of);

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -232,7 +232,6 @@ impl Default for Context<'_> {
             resolver: None,
         };
 
-        ctx.add_function("string", functions::string);
         ctx.add_function("double", functions::double);
         ctx.add_function("int", functions::int);
         ctx.add_function("uint", functions::uint);

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -22,6 +22,7 @@ impl<'a> Env<'a> {
         let mut env = Env::default();
         types::bytes::stdlib(&mut env);
         types::double::stdlib(&mut env);
+        types::int::stdlib(&mut env);
         types::list::stdlib(&mut env);
         types::map::stdlib(&mut env);
         types::string::stdlib(&mut env);

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -21,6 +21,7 @@ impl<'a> Env<'a> {
     pub fn stdlib() -> Env<'a> {
         let mut env = Env::default();
         types::bytes::stdlib(&mut env);
+        types::double::stdlib(&mut env);
         types::list::stdlib(&mut env);
         types::map::stdlib(&mut env);
         types::string::stdlib(&mut env);

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -24,6 +24,12 @@ impl<'a> Env<'a> {
         types::list::stdlib(&mut env);
         types::map::stdlib(&mut env);
         types::string::stdlib(&mut env);
+
+        #[cfg(feature = "chrono")]
+        {
+            types::duration::stdlib(&mut env);
+            types::timestamp::stdlib(&mut env);
+        }
         env
     }
 

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -26,6 +26,7 @@ impl<'a> Env<'a> {
         types::list::stdlib(&mut env);
         types::map::stdlib(&mut env);
         types::string::stdlib(&mut env);
+        types::uint::stdlib(&mut env);
 
         #[cfg(feature = "chrono")]
         {

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -847,11 +847,7 @@ mod tests {
 
     #[test]
     fn test_contains() {
-        let tests = vec![
-            ("list", "[1, 2, 3].contains(3) == true"),
-            ("map", "{1: true, 2: true, 3: true}.contains(3) == true"),
-            ("string", "'foobar'.contains('bar') == true"),
-        ];
+        let tests = vec![("string", "'foobar'.contains('bar') == true")];
 
         for (name, script) in tests {
             assert_eq!(test_script(script, None), Ok(true.into()), "{name}");

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -633,11 +633,11 @@ mod tests {
             ),
             (
                 "timestamp string",
-                "timestamp('2023-05-28T00:00:00Z').string() == '2023-05-28T00:00:00+00:00'",
+                "string(timestamp('2023-05-28T00:00:00Z')) == '2023-05-28T00:00:00+00:00'",
             ),
             (
                 "timestamp timestamp",
-                "timestamp(timestamp('2023-05-28T00:00:00Z')).string() == '2023-05-28T00:00:00+00:00'",
+                "string(timestamp(timestamp('2023-05-28T00:00:00Z'))) == '2023-05-28T00:00:00+00:00'",
             ),
             (
                 "timestamp getFullYear",
@@ -784,10 +784,10 @@ mod tests {
     #[test]
     fn test_chrono_string() {
         [
-            ("duration", "duration('1h30m').string() == '1h30m0s'"),
+            ("duration", "string(duration('1h30m')) == '1h30m0s'"),
             (
                 "timestamp",
-                "timestamp('2023-05-29T00:00:00Z').string() == '2023-05-29T00:00:00+00:00'",
+                "string(timestamp('2023-05-29T00:00:00Z')) == '2023-05-29T00:00:00+00:00'",
             ),
         ]
         .iter()
@@ -841,10 +841,10 @@ mod tests {
     #[test]
     fn test_string() {
         [
-            ("string", "'foo'.string() == 'foo'"),
-            ("int", "10.string() == '10'"),
-            ("float", "10.5.string() == '10.5'"),
-            ("bytes", "b'foo'.string() == 'foo'"),
+            ("string", "string('foo') == 'foo'"),
+            ("int", "string(10) == '10'"),
+            ("float", "string(10.5) == '10.5'"),
+            ("bytes", "string(b'foo') == 'foo'"),
         ]
         .iter()
         .for_each(assert_script);

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -875,8 +875,10 @@ mod tests {
     #[test]
     fn test_uint() {
         [
-            ("string", "'10'.uint() == 10.uint()"),
-            ("double", "10.5.uint() == 10.uint()"),
+            ("uint", "uint(10u) == 10u"),
+            ("int", "uint(10) == 10u"),
+            ("string", "uint('10') == 10u"),
+            ("double", "uint(10.5) == 10u"),
         ]
         .iter()
         .for_each(assert_script);

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -885,10 +885,10 @@ mod tests {
     #[test]
     fn test_int() {
         [
-            ("string", "'10'.int() == 10"),
-            ("int", "10.int() == 10"),
-            ("uint", "10.uint().int() == 10"),
-            ("double", "10.5.int() == 10"),
+            ("string", "int('10') == 10"),
+            ("int", "int(10) == 10"),
+            ("uint", "int(10u) == 10"),
+            ("double", "int(10.5) == 10"),
         ]
         .iter()
         .for_each(assert_script);

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -552,7 +552,14 @@ mod tests {
             ("max no args", "max() == null"),
         ]
         .iter()
-        .for_each(assert_script);
+        .for_each(|a| {
+            let input: &(&str, &str) = a;
+            let mut context = Context::default();
+            context.add_function("max", super::max);
+            let ctx = Some(context);
+            let r = test_script(input.1, ctx);
+            assert_eq!(r, Ok(true.into()), "{}", input.0);
+        });
     }
 
     #[test]
@@ -571,7 +578,14 @@ mod tests {
             ("min no args", "min() == null"),
         ]
         .iter()
-        .for_each(assert_script);
+        .for_each(|a| {
+            let input: &(&str, &str) = a;
+            let mut context = Context::default();
+            context.add_function("min", super::min);
+            let ctx = Some(context);
+            let r = test_script(input.1, ctx);
+            assert_eq!(r, Ok(true.into()), "{}", input.0);
+        });
     }
 
     #[test]

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -625,6 +625,10 @@ mod tests {
                 "timestamp('2023-05-28T00:00:00Z').string() == '2023-05-28T00:00:00+00:00'",
             ),
             (
+                "timestamp timestamp",
+                "timestamp(timestamp('2023-05-28T00:00:00Z')).string() == '2023-05-28T00:00:00+00:00'",
+            ),
+            (
                 "timestamp getFullYear",
                 "timestamp('2023-05-28T00:00:00Z').getFullYear() == 2023",
             ),

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -864,9 +864,9 @@ mod tests {
     #[test]
     fn test_double() {
         [
-            ("string", "'10'.double() == 10.0"),
-            ("int", "10.double() == 10.0"),
-            ("double", "10.0.double() == 10.0"),
+            ("string", "double('10') == 10.0"),
+            ("int", "double(10) == 10.0"),
+            ("double", "double(10.0) == 10.0"),
         ]
         .iter()
         .for_each(assert_script);

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -268,26 +268,6 @@ pub fn optional_or_value(This(this): This<Value>, other: Value) -> Result<Value>
     }
 }
 
-/// Returns true if a string starts with another string.
-///
-/// # Example
-/// ```cel
-/// "abc".startsWith("a") == true
-/// ```
-pub fn starts_with(This(this): This<Arc<String>>, prefix: Arc<String>) -> bool {
-    this.starts_with(prefix.as_str())
-}
-
-/// Returns true if a string ends with another string.
-///
-/// # Example
-/// ```cel
-/// "abc".endsWith("c") == true
-/// ```
-pub fn ends_with(This(this): This<Arc<String>>, suffix: Arc<String>) -> bool {
-    this.ends_with(suffix.as_str())
-}
-
 /// Returns true if a string matches the regular expression.
 ///
 /// # Example

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -314,15 +314,12 @@ pub mod time {
     /// - `1ns` parses as 1 nanosecond
     /// - `1.5ns` parses as 1 nanosecond (sub-nanosecond durations not supported)
     pub fn duration(value: Arc<String>) -> crate::functions::Result<Value> {
-        Ok(Value::Duration(_duration(value.as_str())?))
-    }
-
-    /// A wrapper around [`parse_duration`] that converts errors into [`ExecutionError`].
-    /// and only returns the duration, rather than returning the remaining input.
-    fn _duration(i: &str) -> Result<chrono::Duration> {
-        let (_, duration) = crate::duration::parse_duration(i)
-            .map_err(|e| ExecutionError::function_error("duration", e.to_string()))?;
-        Ok(duration)
+        Ok(Value::Duration({
+            let i = value.as_str();
+            let (_, duration) = crate::duration::parse_duration(i)
+                .map_err(|e| ExecutionError::function_error("duration", e.to_string()))?;
+            Ok(duration)
+        }?))
     }
 
     fn _timestamp(i: &str) -> Result<chrono::DateTime<chrono::FixedOffset>> {

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -289,15 +289,13 @@ pub fn matches(
 use crate::common::value::Val;
 #[cfg(feature = "chrono")]
 pub use time::duration;
-#[cfg(feature = "chrono")]
-pub use time::timestamp;
 
 #[cfg(feature = "chrono")]
 pub mod time {
     use super::Result;
     use crate::magic::This;
     use crate::{ExecutionError, Value};
-    use chrono::{Datelike, Days, Months, Timelike};
+    use chrono::Datelike;
     use std::sync::Arc;
 
     /// Duration parses the provided argument into a [`Value::Duration`] value.
@@ -319,15 +317,6 @@ pub mod time {
         Ok(Value::Duration(_duration(value.as_str())?))
     }
 
-    /// Timestamp parses the provided argument into a [`Value::Timestamp`] value.
-    /// The
-    pub fn timestamp(value: Arc<String>) -> Result<Value> {
-        Ok(Value::Timestamp(
-            chrono::DateTime::parse_from_rfc3339(value.as_str())
-                .map_err(|e| ExecutionError::function_error("timestamp", e.to_string().as_str()))?,
-        ))
-    }
-
     /// A wrapper around [`parse_duration`] that converts errors into [`ExecutionError`].
     /// and only returns the duration, rather than returning the remaining input.
     fn _duration(i: &str) -> Result<chrono::Duration> {
@@ -341,50 +330,14 @@ pub mod time {
             .map_err(|e| ExecutionError::function_error("timestamp", e.to_string()))
     }
 
-    pub fn timestamp_year(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok(this.year().into())
-    }
-
-    pub fn timestamp_month(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok((this.month0() as i32).into())
-    }
-
-    pub fn timestamp_year_day(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        let year = this
-            .checked_sub_days(Days::new(this.day0() as u64))
-            .unwrap()
-            .checked_sub_months(Months::new(this.month0()))
-            .unwrap();
-        Ok(this.signed_duration_since(year).num_days().into())
-    }
-
-    pub fn timestamp_month_day(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok((this.day0() as i32).into())
-    }
-
     pub fn timestamp_date(
         This(this): This<chrono::DateTime<chrono::FixedOffset>>,
     ) -> Result<Value> {
         Ok((this.day() as i32).into())
     }
 
-    pub fn timestamp_weekday(
-        This(this): This<chrono::DateTime<chrono::FixedOffset>>,
-    ) -> Result<Value> {
-        Ok((this.weekday().num_days_from_sunday() as i32).into())
-    }
-
     pub fn get_hours(This(this): This<Value>) -> Result<Value> {
         Ok(match this {
-            Value::Timestamp(ts) => (ts.hour() as i32).into(),
             Value::Duration(d) => (d.num_hours() as i32).into(),
             _ => {
                 return Err(ExecutionError::function_error(
@@ -397,7 +350,6 @@ pub mod time {
 
     pub fn get_minutes(This(this): This<Value>) -> Result<Value> {
         Ok(match this {
-            Value::Timestamp(ts) => (ts.minute() as i32).into(),
             Value::Duration(d) => (d.num_minutes() as i32).into(),
             _ => {
                 return Err(ExecutionError::function_error(
@@ -410,7 +362,6 @@ pub mod time {
 
     pub fn get_seconds(This(this): This<Value>) -> Result<Value> {
         Ok(match this {
-            Value::Timestamp(ts) => (ts.second() as i32).into(),
             Value::Duration(d) => (d.num_seconds() as i32).into(),
             _ => {
                 return Err(ExecutionError::function_error(
@@ -423,7 +374,6 @@ pub mod time {
 
     pub fn get_milliseconds(This(this): This<Value>) -> Result<Value> {
         Ok(match this {
-            Value::Timestamp(ts) => (ts.timestamp_subsec_millis() as i32).into(),
             Value::Duration(d) => (d.num_milliseconds() as i32).into(),
             _ => {
                 return Err(ExecutionError::function_error(

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -126,14 +126,6 @@ pub fn contains(This(this): This<Value>, arg: Value) -> Result<Value> {
                 false
             }
         }
-        Value::Bytes(b) => {
-            if let Value::Bytes(arg) = arg {
-                let s = arg.as_slice();
-                b.windows(arg.len()).any(|w| w == s)
-            } else {
-                false
-            }
-        }
         _ => false,
     }
     .into())
@@ -859,7 +851,6 @@ mod tests {
             ("list", "[1, 2, 3].contains(3) == true"),
             ("map", "{1: true, 2: true, 3: true}.contains(3) == true"),
             ("string", "'foobar'.contains('bar') == true"),
-            ("bytes", "b'foobar'.contains(b'o') == true"),
         ];
 
         for (name, script) in tests {

--- a/cel/src/functions.rs
+++ b/cel/src/functions.rs
@@ -756,6 +756,10 @@ mod tests {
                 "duration getSeconds overflow",
                 "duration('90s').getSeconds() == 90",
             ),
+            (
+                "duration getSeconds overflow",
+                "duration(duration('13s')).getSeconds() == 13",
+            ),
         ]
         .iter()
         .for_each(assert_script);


### PR DESCRIPTION
This ports all standard `stdlib` functions to the `Env`. 
`Optional` related ones still uses the `Context`, I'll work on these next, as they need support for type parameters. Not a huge deal, but they are slightly different than these. 

> [!warning]
> `contains` only really exists on `String`