### PR TITLE
Struct support

### DIFF
--- a/cel/Cargo.toml
+++ b/cel/Cargo.toml
@@ -34,6 +34,7 @@ harness = false
 
 [features]
 default = ["regex", "chrono"]
+structs = []
 bytes = ["dep:bytes"]
 json = ["dep:serde_json", "dep:base64"]
 regex = ["dep:regex"]

--- a/cel/src/common/types/bool.rs
+++ b/cel/src/common/types/bool.rs
@@ -30,8 +30,8 @@ impl Deref for Bool {
 }
 
 impl Val for Bool {
-    fn get_type(&self) -> Type<'_> {
-        super::BOOL_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::BOOL_TYPE
     }
 
     fn as_comparer(&self) -> Option<&dyn Comparer> {
@@ -117,7 +117,7 @@ mod tests {
     #[test]
     fn test_type() {
         let value = Bool(true);
-        assert_eq!(value.get_type(), types::BOOL_TYPE);
+        assert_eq!(*value.get_type(), types::BOOL_TYPE);
         assert_eq!(value.get_type().kind, Kind::Boolean);
     }
 }

--- a/cel/src/common/types/bool.rs
+++ b/cel/src/common/types/bool.rs
@@ -30,7 +30,7 @@ impl Deref for Bool {
 }
 
 impl Val for Bool {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::BOOL_TYPE
     }
 

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -29,8 +29,8 @@ impl Deref for Bytes {
 }
 
 impl Val for Bytes {
-    fn get_type(&self) -> Type<'_> {
-        super::BYTES_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::BYTES_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn Adder> {

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -29,7 +29,7 @@ impl Deref for Bytes {
 }
 
 impl Val for Bytes {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::BYTES_TYPE
     }
 

--- a/cel/src/common/types/double.rs
+++ b/cel/src/common/types/double.rs
@@ -28,7 +28,7 @@ impl Deref for Double {
 }
 
 impl Val for Double {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::DOUBLE_TYPE
     }
 

--- a/cel/src/common/types/double.rs
+++ b/cel/src/common/types/double.rs
@@ -28,8 +28,8 @@ impl Deref for Double {
 }
 
 impl Val for Double {
-    fn get_type(&self) -> Type<'_> {
-        super::DOUBLE_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::DOUBLE_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn Adder> {
@@ -189,7 +189,7 @@ impl<'a> TryFrom<&'a dyn Val> for &'a f64 {
 fn double<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<Double>, Box<dyn Val>> = match arg.get_type() {
+    let ret: Result<Box<Double>, Box<dyn Val>> = match *arg.get_type() {
         super::DOUBLE_TYPE => arg.downcast::<Double>(),
         super::INT_TYPE => arg
             .downcast::<CelInt>()

--- a/cel/src/common/types/duration.rs
+++ b/cel/src/common/types/duration.rs
@@ -27,7 +27,7 @@ impl Deref for Duration {
 }
 
 impl Val for Duration {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::DURATION_TYPE
     }
 

--- a/cel/src/common/types/duration.rs
+++ b/cel/src/common/types/duration.rs
@@ -27,8 +27,8 @@ impl Deref for Duration {
 }
 
 impl Val for Duration {
-    fn get_type(&self) -> Type<'_> {
-        super::DURATION_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::DURATION_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn Adder> {

--- a/cel/src/common/types/int.rs
+++ b/cel/src/common/types/int.rs
@@ -29,8 +29,8 @@ impl Deref for Int {
 }
 
 impl Val for Int {
-    fn get_type(&self) -> Type<'_> {
-        super::INT_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::INT_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn traits::Adder> {
@@ -219,7 +219,7 @@ impl<'a> TryFrom<&'a dyn Val> for &'a i64 {
 fn int<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<Int>, Box<dyn Val>> = match arg.get_type() {
+    let ret: Result<Box<Int>, Box<dyn Val>> = match *arg.get_type() {
         super::INT_TYPE => arg.downcast::<Int>(),
         super::UINT_TYPE => arg
             .downcast::<CelUInt>()

--- a/cel/src/common/types/int.rs
+++ b/cel/src/common/types/int.rs
@@ -29,7 +29,7 @@ impl Deref for Int {
 }
 
 impl Val for Int {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::INT_TYPE
     }
 

--- a/cel/src/common/types/list.rs
+++ b/cel/src/common/types/list.rs
@@ -37,7 +37,7 @@ impl Deref for DefaultList {
 }
 
 impl Val for DefaultList {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &types::LIST_TYPE
     }
 

--- a/cel/src/common/types/list.rs
+++ b/cel/src/common/types/list.rs
@@ -37,8 +37,8 @@ impl Deref for DefaultList {
 }
 
 impl Val for DefaultList {
-    fn get_type(&self) -> Type<'_> {
-        types::LIST_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &types::LIST_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn Adder> {
@@ -103,7 +103,7 @@ impl Container for DefaultList {
 
 impl Indexer for DefaultList {
     fn get<'a>(&'a self, idx: &dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-        match idx.get_type() {
+        match *idx.get_type() {
             types::INT_TYPE => {
                 let idx: i64 = *idx
                     .downcast_ref::<CelInt>()
@@ -141,7 +141,7 @@ impl Indexer for DefaultList {
 
     fn steal(self: Box<Self>, idx: &dyn Val) -> Result<Box<dyn Val>, ExecutionError> {
         let mut list = self;
-        match idx.get_type() {
+        match *idx.get_type() {
             types::INT_TYPE => {
                 let idx: i64 = *idx
                     .downcast_ref::<CelInt>()

--- a/cel/src/common/types/map.rs
+++ b/cel/src/common/types/map.rs
@@ -34,8 +34,8 @@ impl Deref for DefaultMap {
 }
 
 impl Val for DefaultMap {
-    fn get_type(&self) -> Type<'_> {
-        types::MAP_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &types::MAP_TYPE
     }
 
     fn as_container(&self) -> Option<&dyn Container> {
@@ -316,7 +316,7 @@ impl TryFrom<Box<dyn Val>> for Key {
     type Error = ExecutionError;
 
     fn try_from(value: Box<dyn Val>) -> Result<Self, Self::Error> {
-        let key = match value.get_type() {
+        let key = match *value.get_type() {
             types::BOOL_TYPE => value
                 .downcast_ref::<CelBool>()
                 .copied()

--- a/cel/src/common/types/map.rs
+++ b/cel/src/common/types/map.rs
@@ -34,7 +34,7 @@ impl Deref for DefaultMap {
 }
 
 impl Val for DefaultMap {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &types::MAP_TYPE
     }
 

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -60,7 +60,8 @@ pub enum Kind {
     Unknown,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+// This cannot be made `Clone`, see `OpaqueVal`'s `Drop`
+#[derive(Debug, Eq, PartialEq)]
 pub struct Type<'a> {
     kind: Kind,
     parameters: &'a [&'a Type<'a>],
@@ -70,7 +71,7 @@ pub struct Type<'a> {
 
 impl Type<'_> {
     pub fn is_assignable(&self, val: &dyn Val) -> bool {
-        *self == val.get_type()
+        self == val.get_type()
     }
 }
 

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod map;
 mod null;
 mod optional;
 pub(crate) mod string;
+#[cfg(feature = "structs")]
+pub(crate) mod r#struct;
 #[cfg(feature = "chrono")]
 pub(crate) mod timestamp;
 pub(crate) mod uint;
@@ -31,6 +33,8 @@ pub use map::DefaultMap as CelMap;
 pub use map::Key as CelMapKey;
 pub use null::Null as CelNull;
 pub use optional::Optional as CelOptional;
+#[cfg(feature = "structs")]
+pub use r#struct::Struct as CelStruct;
 pub use string::String as CelString;
 #[cfg(feature = "chrono")]
 pub use timestamp::Timestamp as CelTimestamp;
@@ -237,6 +241,16 @@ impl<'a> Type<'a> {
             parameters: &[],
             runtime_type_name: name,
             trait_mask: 0,
+        }
+    }
+
+    #[cfg(feature = "structs")]
+    pub const fn new_struct_type(name: &'a str) -> Type<'a> {
+        Type {
+            kind: Kind::Struct,
+            parameters: &[],
+            runtime_type_name: name,
+            trait_mask: traits::FIELD_TESTER_TYPE | traits::INDEXER_TYPE,
         }
     }
 

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -188,7 +188,7 @@ pub const UINT_TYPE: Type = Type {
 pub const UNKNOWN_TYPE: Type = Type::simple_type(Kind::Unknown, "unknown");
 
 impl<'a> Type<'a> {
-    pub const fn simple_type(kind: Kind, name: &str) -> Type<'_> {
+    pub const fn simple_type(kind: Kind, name: &'a str) -> Type<'a> {
         Type {
             kind,
             parameters: &[],
@@ -197,7 +197,7 @@ impl<'a> Type<'a> {
         }
     }
 
-    pub const fn new_list_type<'b>(param: &'b [&'b Type<'b>; 1]) -> Type<'b> {
+    pub const fn new_list_type(param: &'a [&'a Type<'a>; 1]) -> Type<'a> {
         Type {
             kind: Kind::List,
             parameters: param,
@@ -210,7 +210,7 @@ impl<'a> Type<'a> {
         }
     }
 
-    pub const fn new_map_type<'b>(param: &'b [&'b Type<'b>; 2]) -> Type<'b> {
+    pub const fn new_map_type(param: &'a [&'a Type<'a>; 2]) -> Type<'a> {
         Type {
             kind: Kind::Map,
             parameters: param,
@@ -222,7 +222,7 @@ impl<'a> Type<'a> {
         }
     }
 
-    pub const fn new_unspecified_type(name: &str) -> Type<'_> {
+    pub const fn new_unspecified_type(name: &'a str) -> Type<'a> {
         Type {
             kind: Kind::Unspecified,
             parameters: &[],
@@ -231,7 +231,7 @@ impl<'a> Type<'a> {
         }
     }
 
-    pub const fn new_opaque_type(name: &str) -> Type<'_> {
+    pub const fn new_opaque_type(name: &'a str) -> Type<'a> {
         Type {
             kind: Kind::Opaque,
             parameters: &[],

--- a/cel/src/common/types/null.rs
+++ b/cel/src/common/types/null.rs
@@ -5,8 +5,8 @@ use crate::common::value::Val;
 pub struct Null;
 
 impl Val for Null {
-    fn get_type(&self) -> Type<'_> {
-        super::NULL_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::NULL_TYPE
     }
 
     fn equals(&self, other: &dyn Val) -> bool {

--- a/cel/src/common/types/null.rs
+++ b/cel/src/common/types/null.rs
@@ -5,7 +5,7 @@ use crate::common::value::Val;
 pub struct Null;
 
 impl Val for Null {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::NULL_TYPE
     }
 

--- a/cel/src/common/types/optional.rs
+++ b/cel/src/common/types/optional.rs
@@ -21,7 +21,7 @@ impl OptionalInternal {
 }
 
 impl Val for Optional {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::OPTIONAL_TYPE
     }
 

--- a/cel/src/common/types/optional.rs
+++ b/cel/src/common/types/optional.rs
@@ -21,8 +21,8 @@ impl OptionalInternal {
 }
 
 impl Val for Optional {
-    fn get_type(&self) -> Type<'_> {
-        super::OPTIONAL_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::OPTIONAL_TYPE
     }
 
     fn clone_as_boxed(&self) -> Box<dyn Val> {

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -31,7 +31,7 @@ impl Deref for String {
 }
 
 impl Val for String {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::STRING_TYPE
     }
 

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -31,8 +31,8 @@ impl Deref for String {
 }
 
 impl Val for String {
-    fn get_type(&self) -> Type<'_> {
-        super::STRING_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::STRING_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn Adder> {
@@ -188,7 +188,7 @@ fn matches<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Executio
 fn string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<String>, Box<dyn Val>> = match arg.get_type() {
+    let ret: Result<Box<String>, Box<dyn Val>> = match *arg.get_type() {
         super::STRING_TYPE => arg.downcast::<String>(),
         super::INT_TYPE => arg
             .downcast::<CelInt>()

--- a/cel/src/common/types/struct.rs
+++ b/cel/src/common/types/struct.rs
@@ -9,7 +9,7 @@ use crate::{
     ExecutionError,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Struct {
     r#type: Type<'static>,
     entries: BTreeMap<String, Arc<dyn Val>>,
@@ -64,8 +64,10 @@ impl Val for Struct {
         Some(self)
     }
 
-    fn equals(&self, _other: &dyn Val) -> bool {
-        false
+    fn equals(&self, other: &dyn Val) -> bool {
+        other
+            .downcast_ref::<Struct>()
+            .is_some_and(|other| self == other)
     }
 }
 
@@ -104,5 +106,36 @@ impl Drop for Struct {
         // We leak the name on `Struct::new` to get a &'static str, that we now no longer need
         let name = unsafe { String::from_raw_parts(ptr as *mut u8, len, len) };
         std::mem::drop(name);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use crate::common::{
+        types::{CelBool, CelStruct},
+        value::Val,
+    };
+
+    #[test]
+    fn equality() {
+        let mut s1 = CelStruct::new("foo".to_owned());
+        s1.add_field_value(
+            "bar".to_owned(),
+            Cow::<dyn Val>::Owned(Box::new(CelBool::from(true))),
+        );
+        let mut s2 = CelStruct::new("foo".to_owned());
+        assert_ne!(s1, s2);
+        s2.add_field_value(
+            "bar".to_owned(),
+            Cow::<dyn Val>::Owned(Box::new(CelBool::from(true))),
+        );
+        assert_eq!(s1, s2);
+        s2.add_field_value(
+            "bar".to_owned(),
+            Cow::<dyn Val>::Owned(Box::new(CelBool::from(false))),
+        );
+        assert_ne!(s1, s2);
     }
 }

--- a/cel/src/common/types/struct.rs
+++ b/cel/src/common/types/struct.rs
@@ -1,19 +1,35 @@
+use std::{borrow::Cow, collections::BTreeMap, ops::Deref, sync::Arc};
+
 use crate::common::{types::Type, value::Val};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub struct Struct {
     r#type: Type<'static>,
+    entries: BTreeMap<String, Arc<dyn Val>>,
 }
 
 impl Struct {
     pub fn new(name: String) -> Self {
         Self {
             r#type: Type::new_struct_type(name.leak()),
+            entries: BTreeMap::default(),
         }
     }
 
     pub fn name(&self) -> &str {
         self.r#type.name()
+    }
+
+    pub fn field_value(&self, name: &str) -> Option<&dyn Val> {
+        self.entries.get(name).map(Deref::deref)
+    }
+
+    pub fn add_field_value(&mut self, name: String, value: Cow<dyn Val>) {
+        self.entries.insert(name, Arc::from(value.into_owned()));
+    }
+
+    pub fn field_values(&self) -> BTreeMap<String, Arc<dyn Val>> {
+        self.entries.clone()
     }
 }
 
@@ -25,6 +41,11 @@ impl Val for Struct {
     fn clone_as_boxed(&self) -> Box<dyn Val> {
         Box::new(Self {
             r#type: Type::new_struct_type(self.name().to_owned().leak()),
+            entries: self
+                .entries
+                .iter()
+                .map(|(k, v)| (k.clone(), Arc::from(v.clone_as_boxed())))
+                .collect(),
         })
     }
 }

--- a/cel/src/common/types/struct.rs
+++ b/cel/src/common/types/struct.rs
@@ -1,0 +1,44 @@
+use crate::common::{types::Type, value::Val};
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Struct {
+    r#type: Type<'static>,
+}
+
+impl Struct {
+    pub fn new(name: String) -> Self {
+        Self {
+            r#type: Type::new_struct_type(name.leak()),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.r#type.name()
+    }
+}
+
+impl Val for Struct {
+    fn get_type(&self) -> &Type<'_> {
+        &self.r#type
+    }
+
+    fn clone_as_boxed(&self) -> Box<dyn Val> {
+        Box::new(Self {
+            r#type: Type::new_struct_type(self.name().to_owned().leak()),
+        })
+    }
+}
+
+impl Drop for Struct {
+    fn drop(&mut self) {
+        let name = self.r#type.name();
+
+        let ptr = name.as_ptr();
+        let len = name.len();
+
+        // SAFETY `Type` is not `Clone` and as such solely owned by this `Struct` being dropped
+        // We leak the name on `Struct::new` to get a &'static str, that we now no longer need
+        let name = unsafe { String::from_raw_parts(ptr as *mut u8, len, len) };
+        std::mem::drop(name);
+    }
+}

--- a/cel/src/common/types/struct.rs
+++ b/cel/src/common/types/struct.rs
@@ -1,6 +1,13 @@
 use std::{borrow::Cow, collections::BTreeMap, ops::Deref, sync::Arc};
 
-use crate::common::{types::Type, value::Val};
+use crate::{
+    common::{
+        traits::Indexer,
+        types::{CelString, Type},
+        value::Val,
+    },
+    ExecutionError,
+};
 
 #[derive(Debug)]
 pub struct Struct {
@@ -47,6 +54,42 @@ impl Val for Struct {
                 .map(|(k, v)| (k.clone(), Arc::from(v.clone_as_boxed())))
                 .collect(),
         })
+    }
+
+    fn as_indexer(&self) -> Option<&dyn crate::common::traits::Indexer> {
+        Some(self)
+    }
+
+    fn into_indexer(self: Box<Self>) -> Option<Box<dyn crate::common::traits::Indexer>> {
+        Some(self)
+    }
+
+    fn equals(&self, _other: &dyn Val) -> bool {
+        false
+    }
+}
+
+impl Indexer for Struct {
+    fn get<'a>(&'a self, idx: &dyn Val) -> Result<Cow<'a, dyn Val>, crate::ExecutionError> {
+        if let Some(field) = idx.downcast_ref::<CelString>() {
+            self.field_value(field.inner())
+                .map(Cow::Borrowed)
+                .ok_or(ExecutionError::NoSuchKey(Arc::new(String::from(
+                    field.inner(),
+                ))))
+        } else {
+            Err(ExecutionError::UnsupportedIndex(
+                idx.try_into()?,
+                (self as &dyn Val).try_into()?,
+            ))
+        }
+    }
+
+    fn steal(self: Box<Self>, idx: &dyn Val) -> Result<Box<dyn Val>, crate::ExecutionError> {
+        // TODO: Can't implement this right now really, as we impl `Drop`, can't take ownership of
+        // the fields easily... let's see if this pattern sticks first, then we'll optimize the call
+        // to be no copy
+        self.get(idx).map(Cow::into_owned)
     }
 }
 

--- a/cel/src/common/types/struct.rs
+++ b/cel/src/common/types/struct.rs
@@ -41,7 +41,7 @@ impl Struct {
 }
 
 impl Val for Struct {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &self.r#type
     }
 

--- a/cel/src/common/types/timestamp.rs
+++ b/cel/src/common/types/timestamp.rs
@@ -23,8 +23,8 @@ impl Timestamp {
 }
 
 impl Val for Timestamp {
-    fn get_type(&self) -> Type<'_> {
-        super::TIMESTAMP_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::TIMESTAMP_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn Adder> {

--- a/cel/src/common/types/timestamp.rs
+++ b/cel/src/common/types/timestamp.rs
@@ -23,7 +23,7 @@ impl Timestamp {
 }
 
 impl Val for Timestamp {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::TIMESTAMP_TYPE
     }
 

--- a/cel/src/common/types/uint.rs
+++ b/cel/src/common/types/uint.rs
@@ -28,7 +28,7 @@ impl Deref for UInt {
 }
 
 impl Val for UInt {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &super::UINT_TYPE
     }
 

--- a/cel/src/common/types/uint.rs
+++ b/cel/src/common/types/uint.rs
@@ -28,8 +28,8 @@ impl Deref for UInt {
 }
 
 impl Val for UInt {
-    fn get_type(&self) -> Type<'_> {
-        super::UINT_TYPE
+    fn get_type(&self) -> &Type<'_> {
+        &super::UINT_TYPE
     }
 
     fn as_adder(&self) -> Option<&dyn Adder> {
@@ -240,7 +240,7 @@ impl<'a> TryFrom<&'a dyn Val> for &'a u64 {
 fn uint<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<UInt>, Box<dyn Val>> = match arg.get_type() {
+    let ret: Result<Box<UInt>, Box<dyn Val>> = match *arg.get_type() {
         super::UINT_TYPE => arg.downcast::<UInt>(),
         super::INT_TYPE => arg
             .downcast::<CelInt>()

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 use std::fmt::Debug;
 
 pub trait Val: Any + Debug + Send + Sync {
-    fn get_type(&self) -> Type<'_>;
+    fn get_type(&self) -> &Type<'_>;
 
     fn as_adder(&self) -> Option<&dyn Adder> {
         None
@@ -110,7 +110,7 @@ mod test {
     use std::borrow::Cow;
 
     fn test(val: &dyn Val) -> bool {
-        val.get_type() == types::STRING_TYPE
+        *val.get_type() == types::STRING_TYPE
     }
 
     #[test]

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 use std::fmt::Debug;
 
 pub trait Val: Any + Debug + Send + Sync {
-    fn get_type(&self) -> &Type<'_>;
+    fn get_type<'a>(&self) -> &Type<'a>;
 
     fn as_adder(&self) -> Option<&dyn Adder> {
         None

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -101,6 +101,8 @@ impl PartialEq for dyn Val {
     }
 }
 
+impl Eq for dyn Val {}
+
 #[cfg(test)]
 mod test {
     use crate::common::types;

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -151,7 +151,14 @@ impl<'a> StructDef<'a> {
         fields: BTreeMap<String, std::borrow::Cow<dyn Val>>,
     ) -> Result<CelStruct, ExecutionError> {
         let mut s = CelStruct::new(self.name.clone());
-        // TODO: insert default values
+        let mut fields = fields;
+        for (field, default) in &self.defaults {
+            if let Some(value) = fields.remove(field) {
+                s.add_field_value(field.clone(), value);
+            } else {
+                s.add_field_value(field.clone(), Cow::Owned(default.clone_as_boxed()));
+            }
+        }
         for (field, value) in fields {
             match self.fields.get(&field) {
                 Some(t) => {

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -4,6 +4,8 @@ use crate::common::{
     types::{self, Type},
     value::Val,
 };
+#[cfg(feature = "structs")]
+use crate::{common::types::CelStruct, ExecutionError};
 use std::{
     borrow::Cow,
     collections::{
@@ -15,6 +17,7 @@ use std::{
 #[derive(Default)]
 pub struct Env<'a> {
     functions: BTreeMap<String, FunctionDecl<'a>>,
+    structs: BTreeMap<String, StructDef<'a>>,
 }
 
 impl<'a> Env<'a> {
@@ -97,6 +100,78 @@ impl<'a> Env<'a> {
             None => None,
             Some(fn_decl) => fn_decl.find_overload(true, args),
         }
+    }
+
+    pub fn add_struct(&mut self, def: StructDef<'a>) {
+        self.structs.insert(def.name.clone(), def);
+    }
+
+    #[cfg(feature = "structs")]
+    pub(crate) fn find_struct(&self, name: &str) -> Option<&StructDef<'a>> {
+        self.structs.get(name)
+    }
+}
+
+pub struct StructDef<'a> {
+    name: String,
+    fields: BTreeMap<String, Type<'a>>,
+    defaults: BTreeMap<String, Box<dyn Val>>,
+}
+
+impl<'a> StructDef<'a> {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+            fields: Default::default(),
+            defaults: Default::default(),
+        }
+    }
+
+    pub fn add_field(self, field: String, t: Type<'a>) -> Self {
+        self.add_field_with_default(field, t, None)
+    }
+
+    pub fn add_field_with_default(
+        self,
+        field: String,
+        t: Type<'a>,
+        default: Option<Box<dyn Val>>,
+    ) -> Self {
+        let mut def = self;
+        def.fields.insert(field.clone(), t);
+        if let Some(default) = default {
+            def.defaults.insert(field, default);
+        }
+        def
+    }
+
+    #[cfg(feature = "structs")]
+    pub(crate) fn new_struct(
+        &self,
+        fields: BTreeMap<String, std::borrow::Cow<dyn Val>>,
+    ) -> Result<CelStruct, ExecutionError> {
+        let mut s = CelStruct::new(self.name.clone());
+        // TODO: insert default values
+        for (field, value) in fields {
+            match self.fields.get(&field) {
+                Some(t) => {
+                    if t != value.get_type() {
+                        return Err(ExecutionError::UnexpectedType {
+                            got: value.get_type().name().to_owned(),
+                            want: format!("{} for field {field} in {}", t.name(), self.name),
+                        });
+                    }
+                    s.add_field_value(field, value);
+                }
+                None => {
+                    return Err(ExecutionError::NoSuchKey(std::sync::Arc::new(format!(
+                        "field `{field}` on struct `{}`",
+                        self.name
+                    ))))
+                }
+            }
+        }
+        Ok(s)
     }
 }
 

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -116,6 +116,8 @@ pub enum ExecutionError {
     Overflow(&'static str, Value, Value),
     #[error("Index out of bounds: {0:?}")]
     IndexOutOfBounds(Value),
+    #[error("InternalError: {0:?}")]
+    InternalError(String),
 }
 
 impl ExecutionError {

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1506,7 +1506,20 @@ impl Value {
                 }
                 #[cfg(feature = "structs")]
                 {
-                    let s = CelStruct::new(name);
+                    let mut s = CelStruct::new(name);
+                    for entry in &strct.entries {
+                        match &entry.expr {
+                            EntryExpr::StructField(expr) => {
+                                let f = expr.field.clone();
+                                s.add_field_value(f, Value::resolve_val(&expr.value, ctx)?);
+                            }
+                            EntryExpr::MapEntry(entry) => {
+                                return Err(ExecutionError::InternalError(format!(
+                                    "Expected struct_field_expr, got {entry:?}"
+                                )))
+                            }
+                        }
+                    }
                     Ok(Cow::<dyn Val>::Owned(Box::new(s)))
                 }
             }
@@ -2582,7 +2595,13 @@ mod tests {
     mod structs {
         use std::sync::Arc;
 
-        use crate::{common::types::CelStruct, Context, Program, Value};
+        use crate::{
+            common::{
+                types::{CelBool, CelInt},
+                value::Val,
+            },
+            Context, Program, Value,
+        };
 
         #[test]
         fn test_empty_struct() {
@@ -2590,10 +2609,34 @@ mod tests {
             let value = program.execute(&Context::default()).unwrap();
             match value {
                 Value::Struct(s) => assert_eq!(s.name(), "cel.MyStruct"),
-                _ => assert_eq!(
-                    value,
-                    Value::Struct(Arc::new(CelStruct::new("cel.MyStruct".to_string())))
-                ),
+                _ => panic!("This can't be!"),
+            }
+        }
+
+        #[test]
+        fn test_struct() {
+            let program =
+                Program::compile("cel.Problem { solved: 0 != null, answer: 21 * 2 }").unwrap();
+            let value = program.execute(&Context::default()).unwrap();
+            match value {
+                Value::Struct(s) => {
+                    assert_eq!(s.name(), "cel.Problem");
+                    assert_eq!(
+                        s.field_value("solved"),
+                        Some(&CelBool::from(true) as &dyn Val)
+                    );
+                    assert_eq!(s.field_value("answer"), Some(&CelInt::from(42) as &dyn Val));
+                    assert_eq!(s.field_values().len(), 2);
+                    assert_eq!(
+                        s.field_values().get("solved").cloned(),
+                        Some(Arc::new(CelBool::from(true)) as Arc<dyn Val>)
+                    );
+                    assert_eq!(
+                        s.field_values().get("answer").cloned(),
+                        Some(Arc::new(CelInt::from(42)) as Arc<dyn Val>)
+                    );
+                }
+                _ => panic!("This can't be!"),
             }
         }
     }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1511,12 +1511,19 @@ impl Value {
                 }
                 #[cfg(feature = "structs")]
                 {
-                    let mut s = CelStruct::new(name);
+                    let struct_def =
+                        ctx.env()
+                            .find_struct(&name)
+                            .ok_or(ExecutionError::UnexpectedType {
+                                got: name.to_owned(),
+                                want: "known struct".to_owned(),
+                            })?;
+                    let mut fields = std::collections::BTreeMap::new();
                     for entry in &strct.entries {
                         match &entry.expr {
                             EntryExpr::StructField(expr) => {
                                 let f = expr.field.clone();
-                                s.add_field_value(f, Value::resolve_val(&expr.value, ctx)?);
+                                fields.insert(f, Value::resolve_val(&expr.value, ctx)?);
                             }
                             EntryExpr::MapEntry(entry) => {
                                 return Err(ExecutionError::InternalError(format!(
@@ -1525,6 +1532,7 @@ impl Value {
                             }
                         }
                     }
+                    let s = struct_def.new_struct(fields)?;
                     Ok(Cow::<dyn Val>::Owned(Box::new(s)))
                 }
             }
@@ -2602,16 +2610,19 @@ mod tests {
 
         use crate::{
             common::{
-                types::{CelBool, CelInt},
+                types::{self, CelBool, CelInt},
                 value::Val,
             },
-            Context, ExecutionError, Program, Value,
+            env::StructDef,
+            Context, Env, ExecutionError, Program, Value,
         };
 
         #[test]
         fn test_empty_struct() {
+            let mut env = Env::stdlib();
+            env.add_struct(StructDef::new(String::from("cel.MyStruct")));
             let program = Program::compile("cel.MyStruct {}").unwrap();
-            let value = program.execute(&Context::default()).unwrap();
+            let value = program.execute(&Context::with_env(Arc::new(env))).unwrap();
             match value {
                 Value::Struct(s) => assert_eq!(s.name(), "cel.MyStruct"),
                 _ => panic!("This can't be!"),
@@ -2620,9 +2631,15 @@ mod tests {
 
         #[test]
         fn test_struct() {
+            let mut env = Env::stdlib();
+            env.add_struct(
+                StructDef::new(String::from("cel.Problem"))
+                    .add_field(String::from("solved"), types::BOOL_TYPE)
+                    .add_field(String::from("answer"), types::INT_TYPE),
+            );
             let program =
                 Program::compile("cel.Problem { solved: 0 != null, answer: 21 * 2 }").unwrap();
-            let value = program.execute(&Context::default()).unwrap();
+            let value = program.execute(&Context::with_env(Arc::new(env))).unwrap();
             match value {
                 Value::Struct(s) => {
                     assert_eq!(s.name(), "cel.Problem");
@@ -2647,18 +2664,58 @@ mod tests {
 
         #[test]
         fn test_struct_field_access() {
+            let mut env = Env::stdlib();
+            env.add_struct(
+                StructDef::new(String::from("cel.MyStruct"))
+                    .add_field("some".into(), types::STRING_TYPE),
+            );
             let program = Program::compile("cel.MyStruct { some: 'value' }.some").unwrap();
-            let value = program.execute(&Context::default()).unwrap();
+            let value = program.execute(&Context::with_env(env.into())).unwrap();
             assert_eq!(value, Value::String(Arc::new("value".to_owned())));
         }
 
         #[test]
+        fn test_struct_no_such_field() {
+            let mut env = Env::stdlib();
+            env.add_struct(
+                StructDef::new(String::from("cel.MyStruct"))
+                    .add_field("some".into(), types::STRING_TYPE),
+            );
+            let program = Program::compile("cel.MyStruct { not_here: 'value' }").unwrap();
+            let result = program.execute(&Context::with_env(env.into()));
+            assert_eq!(
+                result,
+                Err(ExecutionError::NoSuchKey(
+                    String::from("field `not_here` on struct `cel.MyStruct`").into()
+                ))
+            );
+        }
+
+        #[test]
         fn test_struct_no_such_field_access() {
+            let mut env = Env::stdlib();
+            env.add_struct(
+                StructDef::new(String::from("cel.MyStruct"))
+                    .add_field("some".into(), types::STRING_TYPE),
+            );
+            let program = Program::compile("cel.MyStruct { some: 'value' }.not_here").unwrap();
+            let result = program.execute(&Context::with_env(env.into()));
+            assert_eq!(
+                result,
+                Err(ExecutionError::NoSuchKey(String::from("not_here").into()))
+            );
+        }
+
+        #[test]
+        fn unknown_struct() {
             let program = Program::compile("cel.MyStruct { some: 'value' }.not_here").unwrap();
             let result = program.execute(&Context::default());
             assert_eq!(
                 result,
-                Err(ExecutionError::NoSuchKey(String::from("not_here").into()))
+                Err(ExecutionError::UnexpectedType {
+                    got: String::from("cel.MyStruct"),
+                    want: String::from("known struct")
+                })
             );
         }
     }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -421,7 +421,7 @@ impl Debug for OpaqueVal {
 }
 
 impl Val for OpaqueVal {
-    fn get_type(&self) -> &Type<'_> {
+    fn get_type<'a>(&self) -> &Type<'a> {
         &self.r#type
     }
 

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -561,6 +561,8 @@ pub enum Value {
     #[cfg(feature = "chrono")]
     Timestamp(chrono::DateTime<chrono::FixedOffset>),
     Opaque(Arc<dyn Opaque>),
+    #[cfg(feature = "structs")]
+    Struct(Arc<CelStruct>),
     Null,
 }
 
@@ -582,6 +584,8 @@ impl Debug for Value {
             Value::Timestamp(t) => write!(f, "Timestamp({:?})", t),
             Value::Opaque(o) => write!(f, "Opaque<{}>({:?})", o.runtime_type_name(), o.as_debug()),
             Value::Null => write!(f, "Null"),
+            #[cfg(feature = "structs")]
+            Value::Struct(s) => write!(f, "{} {{}}", s.name()),
         }
     }
 }
@@ -601,6 +605,8 @@ pub enum ValueType {
     Timestamp,
     Opaque,
     Null,
+    #[cfg(feature = "structs")]
+    Struct,
 }
 
 impl Display for ValueType {
@@ -619,6 +625,8 @@ impl Display for ValueType {
             ValueType::Duration => write!(f, "duration"),
             ValueType::Timestamp => write!(f, "timestamp"),
             ValueType::Null => write!(f, "null"),
+            #[cfg(feature = "structs")]
+            ValueType::Struct => write!(f, "struct"),
         }
     }
 }
@@ -641,6 +649,8 @@ impl Value {
             #[cfg(feature = "chrono")]
             Value::Timestamp(_) => ValueType::Timestamp,
             Value::Null => ValueType::Null,
+            #[cfg(feature = "structs")]
+            Value::Struct(_) => ValueType::Struct,
         }
     }
 
@@ -917,6 +927,19 @@ impl TryFrom<&dyn Val> for Value {
                 }
             })),
             _ => {
+                #[cfg(feature = "structs")]
+                {
+                    if let Some(v) = v.downcast_ref::<CelStruct>() {
+                        use crate::common::value::Downcast;
+
+                        return match v.clone_as_boxed().downcast::<CelStruct>() {
+                            Ok(v) => Ok(Value::Struct(Arc::new(*v))),
+                            Err(v) => Err(ExecutionError::InternalError(format!(
+                                "Not a Struct: `{v:?}`"
+                            ))),
+                        };
+                    }
+                }
                 if let Some(opaque) = v.downcast_ref::<OpaqueVal>() {
                     Ok(Value::Opaque(opaque.val.clone()))
                 } else {
@@ -1473,7 +1496,20 @@ impl Value {
                     Value::resolve_val(&comprehension.result, &ctx)?.into_owned(),
                 ))
             }
-            Expr::Struct(_) => todo!("Support structs!"),
+            Expr::Struct(strct) => {
+                let name = strct.type_name.clone();
+                #[cfg(not(feature = "structs"))]
+                {
+                    Err(ExecutionError::InternalError(format!(
+                        "Found struct {name}, feature not enabled!"
+                    )))
+                }
+                #[cfg(feature = "structs")]
+                {
+                    let s = CelStruct::new(name);
+                    Ok(Cow::<dyn Val>::Owned(Box::new(s)))
+                }
+            }
             Expr::Unspecified => panic!("Can't evaluate Unspecified Expr"),
         }
     }
@@ -2539,6 +2575,26 @@ mod tests {
                     map: Arc::from(HashMap::new())
                 }))
             );
+        }
+    }
+
+    #[cfg(feature = "structs")]
+    mod structs {
+        use std::sync::Arc;
+
+        use crate::{common::types::CelStruct, Context, Program, Value};
+
+        #[test]
+        fn test_empty_struct() {
+            let program = Program::compile("cel.MyStruct {}").unwrap();
+            let value = program.execute(&Context::default()).unwrap();
+            match value {
+                Value::Struct(s) => assert_eq!(s.name(), "cel.MyStruct"),
+                _ => assert_eq!(
+                    value,
+                    Value::Struct(Arc::new(CelStruct::new("cel.MyStruct".to_string())))
+                ),
+            }
         }
     }
 }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -409,18 +409,20 @@ impl dyn Opaque {
     }
 }
 
-#[derive(Clone)]
-struct OpaqueVal(Arc<dyn Opaque>);
+struct OpaqueVal {
+    r#type: Type<'static>,
+    val: Arc<dyn Opaque>,
+}
 
 impl Debug for OpaqueVal {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "OpaqueVal<{}>", self.0.runtime_type_name())
+        write!(f, "OpaqueVal<{}>", self.val.runtime_type_name())
     }
 }
 
 impl Val for OpaqueVal {
-    fn get_type(&self) -> Type<'_> {
-        Type::new_opaque_type(self.0.runtime_type_name())
+    fn get_type(&self) -> &Type<'_> {
+        &self.r#type
     }
 
     fn equals(&self, other: &dyn Val) -> bool {
@@ -429,19 +431,43 @@ impl Val for OpaqueVal {
         } else {
             match other.downcast_ref::<OpaqueVal>() {
                 None => false,
-                Some(other) => self.0.opaque_eq(other.0.deref()),
+                Some(other) => self.val.opaque_eq(other.val.deref()),
             }
         }
     }
 
     fn clone_as_boxed(&self) -> Box<dyn Val> {
-        Box::new(self.clone())
+        Box::new(Self {
+            r#type: Type::new_opaque_type(self.val.runtime_type_name().to_owned().leak()),
+            val: self.val.clone(),
+        })
     }
 }
 
 impl OpaqueVal {
+    fn new(val: Arc<dyn Opaque>) -> Self {
+        Self {
+            r#type: Type::new_opaque_type(val.runtime_type_name().to_owned().leak()),
+            val,
+        }
+    }
+
     fn clone_inner(&self) -> Arc<dyn Opaque> {
-        self.0.clone()
+        self.val.clone()
+    }
+}
+
+impl Drop for OpaqueVal {
+    fn drop(&mut self) {
+        let name = self.r#type.name();
+
+        let ptr = name.as_ptr();
+        let len = name.len();
+
+        // SAFETY `Type` is not `Clone` and is solely owned by this
+        // We leak the name on `OpaqueVal::new` to get a &'static str, that we now no longer need
+        let name = unsafe { String::from_raw_parts(ptr as *mut u8, len, len) };
+        std::mem::drop(name);
     }
 }
 
@@ -831,7 +857,7 @@ impl From<Value> for ResolveResult {
 impl TryFrom<&dyn Val> for Value {
     type Error = ExecutionError;
     fn try_from(v: &dyn Val) -> Result<Self, Self::Error> {
-        match v.get_type() {
+        match *v.get_type() {
             BOOL_TYPE => Ok(Value::Bool(*v.downcast_ref::<CelBool>().unwrap().inner())),
             INT_TYPE => Ok(Value::Int(*v.downcast_ref::<CelInt>().unwrap().inner())),
             UINT_TYPE => Ok(Value::UInt(*v.downcast_ref::<CelUInt>().unwrap().inner())),
@@ -892,7 +918,7 @@ impl TryFrom<&dyn Val> for Value {
             })),
             _ => {
                 if let Some(opaque) = v.downcast_ref::<OpaqueVal>() {
-                    Ok(Value::Opaque(opaque.0.clone()))
+                    Ok(Value::Opaque(opaque.val.clone()))
                 } else {
                     Err(ExecutionError::UnexpectedType {
                         got: v.get_type().name().to_string(),
@@ -941,7 +967,7 @@ impl TryFrom<Value> for Box<dyn Val> {
                         Some(v) => Box::new(CelOptional::of(v.clone().try_into()?)),
                     }
                 } else {
-                    Box::new(OpaqueVal(o))
+                    Box::new(OpaqueVal::new(o))
                 };
                 Ok(v)
             }
@@ -1076,7 +1102,7 @@ impl Value {
                         operators::OPT_SELECT => {
                             let operand = Value::resolve_val(&call.args[0], ctx)?;
                             let field_literal = Value::resolve_val(&call.args[1], ctx)?;
-                            let field = match field_literal.get_type() {
+                            let field = match *field_literal.get_type() {
                                 STRING_TYPE => field_literal
                                     .downcast_ref::<CelString>()
                                     .expect("field must be string"),
@@ -1349,7 +1375,7 @@ impl Value {
                 .ok_or_else(|| ExecutionError::UndeclaredReference(Arc::new(name.to_string())))?),
             Expr::Select(select) => {
                 let left = Value::resolve_val(select.operand.deref(), ctx)?;
-                match left.get_type() {
+                match *left.get_type() {
                     MAP_TYPE => {
                         let key: CelString = select.field.as_str().into();
                         if select.test {
@@ -2020,9 +2046,9 @@ mod tests {
             pub fn my_fn(ftx: &FunctionContext) -> Result<Value, ExecutionError> {
                 if let Some(Some(opaque)) = ftx.this.as_ref().map(|v| v.downcast_ref::<OpaqueVal>())
                 {
-                    if opaque.0.runtime_type_name() == "my_struct" {
+                    if opaque.val.runtime_type_name() == "my_struct" {
                         Ok(opaque
-                            .0
+                            .val
                             .deref()
                             .downcast_ref::<MyStruct>()
                             .unwrap()
@@ -2031,7 +2057,7 @@ mod tests {
                             .into())
                     } else {
                         Err(ExecutionError::UnexpectedType {
-                            got: opaque.0.runtime_type_name().to_string(),
+                            got: opaque.val.runtime_type_name().to_string(),
                             want: "my_struct".to_string(),
                         })
                     }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -1398,9 +1398,9 @@ impl Value {
                 .ok_or_else(|| ExecutionError::UndeclaredReference(Arc::new(name.to_string())))?),
             Expr::Select(select) => {
                 let left = Value::resolve_val(select.operand.deref(), ctx)?;
+                let key: CelString = select.field.as_str().into();
                 match *left.get_type() {
                     MAP_TYPE => {
-                        let key: CelString = select.field.as_str().into();
                         if select.test {
                             Ok(bool(
                                 left.as_container()
@@ -1421,7 +1421,12 @@ impl Value {
                             ))
                         }
                     }
-                    _ => Ok(bool(false)),
+                    _ => Ok(Cow::<dyn Val>::Owned(
+                        left.as_indexer()
+                            .ok_or_else(|| ExecutionError::NoSuchOverload)?
+                            .get(&key)?
+                            .into_owned(),
+                    )),
                 }
             }
             Expr::List(list_expr) => {
@@ -2600,7 +2605,7 @@ mod tests {
                 types::{CelBool, CelInt},
                 value::Val,
             },
-            Context, Program, Value,
+            Context, ExecutionError, Program, Value,
         };
 
         #[test]
@@ -2638,6 +2643,23 @@ mod tests {
                 }
                 _ => panic!("This can't be!"),
             }
+        }
+
+        #[test]
+        fn test_struct_field_access() {
+            let program = Program::compile("cel.MyStruct { some: 'value' }.some").unwrap();
+            let value = program.execute(&Context::default()).unwrap();
+            assert_eq!(value, Value::String(Arc::new("value".to_owned())));
+        }
+
+        #[test]
+        fn test_struct_no_such_field_access() {
+            let program = Program::compile("cel.MyStruct { some: 'value' }.not_here").unwrap();
+            let result = program.execute(&Context::default());
+            assert_eq!(
+                result,
+                Err(ExecutionError::NoSuchKey(String::from("not_here").into()))
+            );
         }
     }
 }

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -2610,7 +2610,7 @@ mod tests {
 
         use crate::{
             common::{
-                types::{self, CelBool, CelInt},
+                types::{self, CelBool, CelInt, CelString},
                 value::Val,
             },
             env::StructDef,
@@ -2689,6 +2689,41 @@ mod tests {
                     String::from("field `not_here` on struct `cel.MyStruct`").into()
                 ))
             );
+        }
+
+        #[test]
+        fn test_struct_with_default() {
+            let mut env = Env::stdlib();
+            env.add_struct(
+                StructDef::new(String::from("cel.MyStruct"))
+                    .add_field("some".into(), types::STRING_TYPE)
+                    .add_field_with_default(
+                        "here".into(),
+                        types::STRING_TYPE,
+                        Some(Box::new(CelString::from("yes"))),
+                    ),
+            );
+            let program = Program::compile("cel.MyStruct { some: 'value' }.here").unwrap();
+            let result = program.execute(&Context::with_env(env.into()));
+            assert_eq!(result, Ok(Value::String(Arc::new(String::from("yes")))));
+        }
+
+        #[test]
+        fn test_struct_with_default_overwritten() {
+            let mut env = Env::stdlib();
+            env.add_struct(
+                StructDef::new(String::from("cel.MyStruct"))
+                    .add_field("some".into(), types::STRING_TYPE)
+                    .add_field_with_default(
+                        "here".into(),
+                        types::STRING_TYPE,
+                        Some(Box::new(CelString::from("yes"))),
+                    ),
+            );
+            let program =
+                Program::compile("cel.MyStruct { some: 'value', here: 'totally' }.here").unwrap();
+            let result = program.execute(&Context::with_env(env.into()));
+            assert_eq!(result, Ok(Value::String(Arc::new(String::from("totally")))));
         }
 
         #[test]


### PR DESCRIPTION
Fixes #73 

I suggest reviewing the individual patches (WIP):

 - First, I changed `Type`s to be passed by ref only
   - `Type` is not `Clone` anymore, see `OpaqueVal`'s `Drop` impl.
   - The reason is, in dynamic scenarios (e.g. protobuf reflection), you don't know the struct types ahead of compilation
 - Fixed some lifetimes on `Type`
 - Wire frame for integrating `Struct`s 

I am doing this behind a feature flag (`structs`) tho. It'll be opt-in. 
This type actually "leaks" `CelStruct` (from the new type system) in `Value`.  But we should think about what to do with that `Value` type... 
I'm slowly wondering if `Type` shouldn't be holding `Arc` instead of refs and possibly even be `Copy`. But `const` optimizations are out then... I don't know... thoughts?

I'll keep on adding to this branch, to support fields et al. The idea for a first step is "dynamic `Struct`s", as we don't do type validation (check phase) anyways... pretty much "all" is dynamic still, other than overload dispatching... which should that become public too already (currently sort of is)?

cc/ @clarkmcc @adam-cattermole 
   