### PR TITLE
No more explicit lifetimes on `Type` type (and all others from there)

### DIFF
--- a/cel/src/common/decls.rs
+++ b/cel/src/common/decls.rs
@@ -4,13 +4,13 @@ use crate::common::functions::Function;
 use crate::common::types::Type;
 use crate::common::value::Val;
 
-pub struct FunctionDecl<'a> {
+pub struct FunctionDecl {
     pub name: String,
-    overloads: Vec<OverloadDecl<'a>>,
+    overloads: Vec<OverloadDecl>,
 }
 
-impl<'a> FunctionDecl<'a> {
-    pub fn new(name: &str) -> FunctionDecl<'a> {
+impl FunctionDecl {
+    pub fn new(name: &str) -> FunctionDecl {
         FunctionDecl {
             name: name.to_string(),
             overloads: Vec::default(),
@@ -37,7 +37,7 @@ impl<'a> FunctionDecl<'a> {
         &mut self,
         id: String,
         member_function: bool,
-        arg_types: Vec<Type<'a>>,
+        arg_types: Vec<Type>,
         op: Function,
     ) -> Result<(), ()> {
         if self.is_present(&id, member_function, &arg_types) {
@@ -52,7 +52,7 @@ impl<'a> FunctionDecl<'a> {
         Ok(())
     }
 
-    fn is_present(&self, name: &str, member_function: bool, arg_types: &[Type<'a>]) -> bool {
+    fn is_present(&self, name: &str, member_function: bool, arg_types: &[Type]) -> bool {
         for overload in &self.overloads {
             if overload.id == name
                 || (overload.member_function == member_function && overload.arg_types == arg_types)
@@ -64,9 +64,9 @@ impl<'a> FunctionDecl<'a> {
     }
 }
 
-pub struct OverloadDecl<'a> {
+pub struct OverloadDecl {
     pub id: String,
-    arg_types: Vec<Type<'a>>,
+    arg_types: Vec<Type>,
     //result_type: &'a Type<'a>,
     member_function: bool,
     //operand_traits: TraitSet,
@@ -76,6 +76,6 @@ pub struct OverloadDecl<'a> {
 #[allow(dead_code)]
 struct VariableDecl<'a, 'b> {
     name: String,
-    var_type: &'a Type<'a>,
+    var_type: &'a Type,
     value: &'b dyn Val,
 }

--- a/cel/src/common/types/bool.rs
+++ b/cel/src/common/types/bool.rs
@@ -30,7 +30,7 @@ impl Deref for Bool {
 }
 
 impl Val for Bool {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::BOOL_TYPE
     }
 

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -29,7 +29,7 @@ impl Deref for Bytes {
 }
 
 impl Val for Bytes {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::BYTES_TYPE
     }
 
@@ -139,7 +139,7 @@ fn string_to_bytes<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, 
     }
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "bytes",
         "string_to_bytes",

--- a/cel/src/common/types/double.rs
+++ b/cel/src/common/types/double.rs
@@ -1,5 +1,5 @@
 use crate::common::traits::{Adder, Comparer, Divider, Multiplier, Negator, Subtractor};
-use crate::common::types::{CelInt, CelString, CelUInt, Type};
+use crate::common::types::{CelInt, CelString, CelUInt, Kind, Type};
 use crate::common::value::{Downcast, Val};
 use crate::{ExecutionError, Value};
 use std::borrow::Cow;
@@ -28,7 +28,7 @@ impl Deref for Double {
 }
 
 impl Val for Double {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::DOUBLE_TYPE
     }
 
@@ -189,15 +189,15 @@ impl<'a> TryFrom<&'a dyn Val> for &'a f64 {
 fn double<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<Double>, Box<dyn Val>> = match *arg.get_type() {
-        super::DOUBLE_TYPE => arg.downcast::<Double>(),
-        super::INT_TYPE => arg
+    let ret: Result<Box<Double>, Box<dyn Val>> = match arg.get_type().kind() {
+        Kind::Double => arg.downcast::<Double>(),
+        Kind::Int => arg
             .downcast::<CelInt>()
             .map(|arg| Box::new(Double::from(*arg.inner() as f64))),
-        super::UINT_TYPE => arg
+        Kind::UInt => arg
             .downcast::<CelUInt>()
             .map(|arg| Box::new(Double::from(*arg.inner() as f64))),
-        super::STRING_TYPE => match arg.downcast::<CelString>() {
+        Kind::String => match arg.downcast::<CelString>() {
             Err(arg) => Err(arg),
             Ok(arg) => match arg.inner().parse::<f64>() {
                 Ok(arg) => Ok(Box::new(Double::from(arg))),
@@ -221,7 +221,7 @@ fn double<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Execution
     }
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "double",
         "double_to_double",

--- a/cel/src/common/types/duration.rs
+++ b/cel/src/common/types/duration.rs
@@ -27,7 +27,7 @@ impl Deref for Duration {
 }
 
 impl Val for Duration {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::DURATION_TYPE
     }
 
@@ -163,7 +163,7 @@ fn duration<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Executi
     })
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "duration",
         "string_to_duration",

--- a/cel/src/common/types/int.rs
+++ b/cel/src/common/types/int.rs
@@ -1,6 +1,6 @@
 use crate::common::traits::Negator;
 use crate::common::traits::{self, Comparer};
-use crate::common::types::{CelDouble, CelString, CelUInt, Type};
+use crate::common::types::{CelDouble, CelString, CelUInt, Kind, Type};
 use crate::common::value::{Downcast, Val};
 use crate::ExecutionError;
 use std::borrow::Cow;
@@ -29,7 +29,7 @@ impl Deref for Int {
 }
 
 impl Val for Int {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::INT_TYPE
     }
 
@@ -219,15 +219,15 @@ impl<'a> TryFrom<&'a dyn Val> for &'a i64 {
 fn int<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<Int>, Box<dyn Val>> = match *arg.get_type() {
-        super::INT_TYPE => arg.downcast::<Int>(),
-        super::UINT_TYPE => arg
+    let ret: Result<Box<Int>, Box<dyn Val>> = match arg.get_type().kind() {
+        Kind::Int => arg.downcast::<Int>(),
+        Kind::UInt => arg
             .downcast::<CelUInt>()
             .map(|arg| Box::new(Int::from(*arg.inner() as i64))),
-        super::DOUBLE_TYPE => arg
+        Kind::Double => arg
             .downcast::<CelDouble>()
             .map(|arg| Box::new(Int::from(*arg.inner() as i64))),
-        super::STRING_TYPE => match arg.downcast::<CelString>() {
+        Kind::String => match arg.downcast::<CelString>() {
             Err(arg) => Err(arg),
             Ok(arg) => match arg.inner().parse::<i64>() {
                 Ok(arg) => Ok(Box::new(Int::from(arg))),
@@ -251,7 +251,7 @@ fn int<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionErr
     }
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload("int", "int64_to_int64", vec![super::INT_TYPE], int)
         .expect("Must be unique id");
     env.add_overload("int", "uint64_to_int64", vec![super::UINT_TYPE], int)

--- a/cel/src/common/types/list.rs
+++ b/cel/src/common/types/list.rs
@@ -1,5 +1,5 @@
 use crate::common::traits::{Adder, Container, Indexer, Iterable, Sizer};
-use crate::common::types::{CelInt, CelUInt, Type};
+use crate::common::types::{CelInt, CelUInt, Kind, Type};
 use crate::common::value::Val;
 use crate::common::{traits, types};
 use crate::ExecutionError;
@@ -37,7 +37,7 @@ impl Deref for DefaultList {
 }
 
 impl Val for DefaultList {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &types::LIST_TYPE
     }
 
@@ -103,8 +103,8 @@ impl Container for DefaultList {
 
 impl Indexer for DefaultList {
     fn get<'a>(&'a self, idx: &dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError> {
-        match *idx.get_type() {
-            types::INT_TYPE => {
+        match idx.get_type().kind() {
+            Kind::Int => {
                 let idx: i64 = *idx
                     .downcast_ref::<CelInt>()
                     .ok_or(ExecutionError::NoSuchOverload)?
@@ -116,7 +116,7 @@ impl Indexer for DefaultList {
                         .as_ref(),
                 ))
             }
-            types::UINT_TYPE => {
+            Kind::UInt => {
                 let idx: u64 = *idx
                     .downcast_ref::<CelUInt>()
                     .ok_or(ExecutionError::NoSuchOverload)?
@@ -141,8 +141,8 @@ impl Indexer for DefaultList {
 
     fn steal(self: Box<Self>, idx: &dyn Val) -> Result<Box<dyn Val>, ExecutionError> {
         let mut list = self;
-        match *idx.get_type() {
-            types::INT_TYPE => {
+        match idx.get_type().kind() {
+            Kind::Int => {
                 let idx: i64 = *idx
                     .downcast_ref::<CelInt>()
                     .ok_or(ExecutionError::NoSuchOverload)?
@@ -152,7 +152,7 @@ impl Indexer for DefaultList {
                 }
                 Ok(list.0.remove(idx as usize))
             }
-            types::UINT_TYPE => {
+            Kind::UInt => {
                 let idx: u64 = *idx
                     .downcast_ref::<CelUInt>()
                     .ok_or(ExecutionError::NoSuchOverload)?
@@ -234,7 +234,7 @@ impl<'a> traits::Iterator<'a> for SliceIterator<'a> {
     }
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "size",
         "size_list",

--- a/cel/src/common/types/map.rs
+++ b/cel/src/common/types/map.rs
@@ -1,5 +1,5 @@
 use crate::common::traits::{Container, Indexer, Iterable, Sizer};
-use crate::common::types::{CelBool, CelInt, CelString, CelUInt, Type};
+use crate::common::types::{CelBool, CelInt, CelString, CelUInt, Kind, Type};
 use crate::common::value::Val;
 use crate::common::{traits, types};
 use crate::ExecutionError;
@@ -34,7 +34,7 @@ impl Deref for DefaultMap {
 }
 
 impl Val for DefaultMap {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &types::MAP_TYPE
     }
 
@@ -316,8 +316,8 @@ impl TryFrom<Box<dyn Val>> for Key {
     type Error = ExecutionError;
 
     fn try_from(value: Box<dyn Val>) -> Result<Self, Self::Error> {
-        let key = match *value.get_type() {
-            types::BOOL_TYPE => value
+        let key = match value.get_type().kind() {
+            Kind::Boolean => value
                 .downcast_ref::<CelBool>()
                 .copied()
                 .map(Key::Bool)
@@ -326,7 +326,7 @@ impl TryFrom<Box<dyn Val>> for Key {
                         value.as_ref().try_into().expect("Can't convert key!"),
                     )
                 })?,
-            types::INT_TYPE => value
+            Kind::Int => value
                 .downcast_ref::<CelInt>()
                 .copied()
                 .map(Key::Int)
@@ -335,7 +335,7 @@ impl TryFrom<Box<dyn Val>> for Key {
                         value.as_ref().try_into().expect("Can't convert key!"),
                     )
                 })?,
-            types::STRING_TYPE => {
+            Kind::String => {
                 let s = super::cast_boxed::<CelString>(value).map_err(|v| {
                     ExecutionError::UnsupportedKeyType(
                         v.as_ref().try_into().expect("Can't convert key!"),
@@ -343,7 +343,7 @@ impl TryFrom<Box<dyn Val>> for Key {
                 })?;
                 Key::String(s.into_inner().into())
             }
-            types::UINT_TYPE => value
+            Kind::UInt => value
                 .downcast_ref::<CelUInt>()
                 .copied()
                 .map(Key::UInt)
@@ -378,7 +378,7 @@ impl<'a> traits::Iterator<'a> for MapKeyIterator<'a> {
     }
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "size",
         "size_map",

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -64,22 +64,34 @@ pub enum Kind {
     Unknown,
 }
 
-// This cannot be made `Clone`, see `OpaqueVal`'s `Drop`
 #[derive(Debug, Eq, PartialEq)]
-pub struct Type<'a> {
+pub struct Type {
     kind: Kind,
-    parameters: &'a [&'a Type<'a>],
-    runtime_type_name: &'a str,
+    parameters: Cow<'static, [Cow<'static, Type>]>,
+    runtime_type_name: Cow<'static, str>,
     trait_mask: TraitSet,
 }
 
-impl Type<'_> {
+impl ToOwned for Type {
+    type Owned = Type;
+
+    fn to_owned(&self) -> Self::Owned {
+        Self {
+            kind: self.kind,
+            parameters: self.parameters.clone(),
+            runtime_type_name: self.runtime_type_name.clone(),
+            trait_mask: self.trait_mask,
+        }
+    }
+}
+
+impl Type {
     pub fn is_assignable(&self, val: &dyn Val) -> bool {
         self == val.get_type()
     }
 }
 
-impl Type<'_> {
+impl Type {
     pub fn kind(&self) -> Kind {
         self.kind
     }
@@ -87,29 +99,29 @@ impl Type<'_> {
 
 pub const ANY_TYPE: Type = Type {
     kind: Kind::Any,
-    parameters: &[],
-    runtime_type_name: "google.protobuf.Any",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("google.protobuf.Any"),
     trait_mask: traits::FIELD_TESTER_TYPE | traits::INDEXER_TYPE,
 };
 
 pub const BOOL_TYPE: Type = Type {
     kind: Kind::Boolean,
-    parameters: &[],
-    runtime_type_name: "bool",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("bool"),
     trait_mask: traits::COMPARER_TYPE | traits::NEGATOR_TYPE,
 };
 
 pub const BYTES_TYPE: Type = Type {
     kind: Kind::Bytes,
-    parameters: &[],
-    runtime_type_name: "bytes",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("bytes"),
     trait_mask: traits::ADDER_TYPE | traits::COMPARER_TYPE | traits::SIZER_TYPE,
 };
 
 pub const DOUBLE_TYPE: Type = Type {
     kind: Kind::Double,
-    parameters: &[],
-    runtime_type_name: "double",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("double"),
     trait_mask: traits::ADDER_TYPE
         | traits::COMPARER_TYPE
         | traits::DIVIDER_TYPE
@@ -120,8 +132,8 @@ pub const DOUBLE_TYPE: Type = Type {
 
 pub const DURATION_TYPE: Type = Type {
     kind: Kind::Duration,
-    parameters: &[],
-    runtime_type_name: "google.protobuf.Duration",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("google.protobuf.Duration"),
     trait_mask: traits::ADDER_TYPE
         | traits::COMPARER_TYPE
         | traits::NEGATOR_TYPE
@@ -129,14 +141,22 @@ pub const DURATION_TYPE: Type = Type {
         | traits::SUBTRACTOR_TYPE,
 };
 
-pub const DYN_TYPE: Type = Type::simple_type(Kind::Dyn, "dyn");
+pub const DYN_TYPE: Type = {
+    let kind = Kind::Dyn;
+    Type {
+        kind,
+        parameters: Cow::Borrowed(&[]),
+        runtime_type_name: Cow::Borrowed("dyn"),
+        trait_mask: 0,
+    }
+};
 
 pub const ERROR_TYPE: Type = Type::simple_type(Kind::Error, "error");
 
 pub const INT_TYPE: Type = Type {
     kind: Kind::Int,
-    parameters: &[],
-    runtime_type_name: "int",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("int"),
     trait_mask: traits::ADDER_TYPE
         | traits::COMPARER_TYPE
         | traits::DIVIDER_TYPE
@@ -146,18 +166,52 @@ pub const INT_TYPE: Type = Type {
         | traits::SUBTRACTOR_TYPE,
 };
 
-pub const LIST_TYPE: Type = Type::new_list_type(&[&DYN_TYPE]);
+pub const LIST_TYPE: Type = {
+    Type {
+        kind: Kind::List,
+        parameters: Cow::Borrowed(&[Cow::Borrowed(&DYN_TYPE)]),
+        runtime_type_name: Cow::Borrowed("list"),
+        trait_mask: traits::ADDER_TYPE
+            | traits::CONTAINER_TYPE
+            | traits::INDEXER_TYPE
+            | traits::ITERABLE_TYPE
+            | traits::SIZER_TYPE,
+    }
+};
 
-pub const MAP_TYPE: Type = Type::new_map_type(&[&DYN_TYPE, &DYN_TYPE]);
+pub const MAP_TYPE: Type = {
+    Type {
+        kind: Kind::Map,
+        parameters: Cow::Borrowed(&[Cow::Borrowed(&DYN_TYPE), Cow::Borrowed(&DYN_TYPE)]),
+        runtime_type_name: Cow::Borrowed("map"),
+        trait_mask: traits::CONTAINER_TYPE
+            | traits::INDEXER_TYPE
+            | traits::ITERABLE_TYPE
+            | traits::SIZER_TYPE,
+    }
+};
 
-pub const NULL_TYPE: Type = Type::simple_type(Kind::NullType, "null_type");
+pub const NULL_TYPE: Type = {
+    let kind = Kind::NullType;
+    Type {
+        kind,
+        parameters: Cow::Borrowed(&[]),
+        runtime_type_name: Cow::Borrowed("null_type"),
+        trait_mask: 0,
+    }
+};
 
-pub const OPTIONAL_TYPE: Type = Type::new_opaque_type("optional_type");
+pub const OPTIONAL_TYPE: Type = Type {
+    kind: Kind::Opaque,
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("optional_type"),
+    trait_mask: 0,
+};
 
 pub const STRING_TYPE: Type = Type {
     kind: Kind::String,
-    parameters: &[],
-    runtime_type_name: "string",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("string"),
     trait_mask: traits::ADDER_TYPE
         | traits::COMPARER_TYPE
         | traits::MATCHER_TYPE
@@ -167,8 +221,8 @@ pub const STRING_TYPE: Type = Type {
 
 pub const TIMESTAMP_TYPE: Type = Type {
     kind: Kind::Timestamp,
-    parameters: &[],
-    runtime_type_name: "google.protobuf.Timestamp",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("google.protobuf.Timestamp"),
     trait_mask: traits::ADDER_TYPE
         | traits::COMPARER_TYPE
         | traits::RECEIVER_TYPE
@@ -179,8 +233,8 @@ pub const TYPE_TYPE: Type = Type::simple_type(Kind::Type, "type");
 
 pub const UINT_TYPE: Type = Type {
     kind: Kind::UInt,
-    parameters: &[],
-    runtime_type_name: "uint",
+    parameters: Cow::Borrowed(&[]),
+    runtime_type_name: Cow::Borrowed("uint"),
     trait_mask: traits::ADDER_TYPE
         | traits::COMPARER_TYPE
         | traits::DIVIDER_TYPE
@@ -191,21 +245,21 @@ pub const UINT_TYPE: Type = Type {
 
 pub const UNKNOWN_TYPE: Type = Type::simple_type(Kind::Unknown, "unknown");
 
-impl<'a> Type<'a> {
-    pub const fn simple_type(kind: Kind, name: &'a str) -> Type<'a> {
+impl Type {
+    pub const fn simple_type(kind: Kind, name: &'static str) -> Type {
         Type {
             kind,
-            parameters: &[],
-            runtime_type_name: name,
+            parameters: Cow::Borrowed(&[]),
+            runtime_type_name: Cow::Borrowed(name),
             trait_mask: 0,
         }
     }
 
-    pub const fn new_list_type(param: &'a [&'a Type<'a>; 1]) -> Type<'a> {
+    pub fn new_list_type(param: &'static [Cow<Type>; 1]) -> Type {
         Type {
             kind: Kind::List,
-            parameters: param,
-            runtime_type_name: "list",
+            parameters: Cow::Borrowed(param),
+            runtime_type_name: Cow::Borrowed("list"),
             trait_mask: traits::ADDER_TYPE
                 | traits::CONTAINER_TYPE
                 | traits::INDEXER_TYPE
@@ -214,11 +268,11 @@ impl<'a> Type<'a> {
         }
     }
 
-    pub const fn new_map_type(param: &'a [&'a Type<'a>; 2]) -> Type<'a> {
+    pub fn new_map_type(param: &'static [Cow<Type>; 2]) -> Type {
         Type {
             kind: Kind::Map,
-            parameters: param,
-            runtime_type_name: "map",
+            parameters: Cow::Borrowed(param),
+            runtime_type_name: Cow::Borrowed("map"),
             trait_mask: traits::CONTAINER_TYPE
                 | traits::INDEXER_TYPE
                 | traits::ITERABLE_TYPE
@@ -226,36 +280,55 @@ impl<'a> Type<'a> {
         }
     }
 
-    pub const fn new_unspecified_type(name: &'a str) -> Type<'a> {
+    pub const fn new_unspecified_type(name: &'static str) -> Type {
         Type {
             kind: Kind::Unspecified,
-            parameters: &[],
-            runtime_type_name: name,
+            parameters: Cow::Borrowed(&[]),
+            runtime_type_name: Cow::Borrowed(name),
             trait_mask: 0,
         }
     }
 
-    pub const fn new_opaque_type(name: &'a str) -> Type<'a> {
+    pub fn new_opaque_type(name: &'static str) -> Type {
         Type {
             kind: Kind::Opaque,
-            parameters: &[],
-            runtime_type_name: name,
+            parameters: Cow::Borrowed(&[]),
+            runtime_type_name: Cow::Borrowed(name),
+            trait_mask: 0,
+        }
+    }
+
+    pub fn new_opaque(name: String) -> Type {
+        Type {
+            kind: Kind::Opaque,
+            parameters: Cow::Borrowed(&[]),
+            runtime_type_name: Cow::Owned(name),
             trait_mask: 0,
         }
     }
 
     #[cfg(feature = "structs")]
-    pub const fn new_struct_type(name: &'a str) -> Type<'a> {
+    pub const fn new_struct_type(name: &'static str) -> Type {
         Type {
             kind: Kind::Struct,
-            parameters: &[],
-            runtime_type_name: name,
+            parameters: Cow::Borrowed(&[]),
+            runtime_type_name: Cow::Borrowed(name),
             trait_mask: traits::FIELD_TESTER_TYPE | traits::INDEXER_TYPE,
         }
     }
 
-    pub fn name(&self) -> &'a str {
-        self.runtime_type_name
+    #[cfg(feature = "structs")]
+    pub const fn new_struct(name: String) -> Type {
+        Type {
+            kind: Kind::Struct,
+            parameters: Cow::Borrowed(&[]),
+            runtime_type_name: Cow::Owned(name),
+            trait_mask: traits::FIELD_TESTER_TYPE | traits::INDEXER_TYPE,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.runtime_type_name
     }
 
     pub fn has_trait(&self, t: u16) -> bool {
@@ -284,7 +357,7 @@ type BinaryFn<A, B> = fn(&A, &B) -> Result<Box<dyn Val>, ExecutionError>;
 
 fn unary_fn<'a, A: Val>(
     args: Vec<Cow<'a, dyn Val>>,
-    type_a: Type<'_>,
+    type_a: Type,
     func: UnaryFn<A>,
 ) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let arg = &args[0];
@@ -299,8 +372,8 @@ fn unary_fn<'a, A: Val>(
 
 fn binary_fn<'a, A: Val, B: Val>(
     args: Vec<Cow<'a, dyn Val>>,
-    type_a: Type<'_>,
-    type_b: Type<'_>,
+    type_a: Type,
+    type_b: Type,
     func: BinaryFn<A, B>,
 ) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let arg1 = &args[0];
@@ -324,39 +397,4 @@ fn noop<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionEr
     let mut args = args;
     let ts = args.remove(0);
     Ok(ts)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parameterized_type() {
-        let param = Type {
-            kind: Kind::Unspecified,
-            parameters: &[],
-            runtime_type_name: "",
-            trait_mask: 0,
-        };
-
-        let t = std::string::String::from("List");
-        let parameterized_list = Type {
-            kind: Kind::List,
-            parameters: &[&param],
-            runtime_type_name: &t,
-            trait_mask: 0,
-        };
-        assert_eq!(&param, parameterized_list.parameters[0]);
-
-        let params = [&param];
-        let list2 = Type::new_list_type(&params);
-        assert_eq!(&param, list2.parameters[0]);
-        assert_eq!(1, list2.parameters.len());
-
-        let params = [&param, &param];
-        let map = Type::new_map_type(&params);
-        assert_eq!(&param, map.parameters[0]);
-        assert_eq!(&param, map.parameters[1]);
-        assert_eq!(2, map.parameters.len());
-    }
 }

--- a/cel/src/common/types/null.rs
+++ b/cel/src/common/types/null.rs
@@ -5,7 +5,7 @@ use crate::common::value::Val;
 pub struct Null;
 
 impl Val for Null {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::NULL_TYPE
     }
 

--- a/cel/src/common/types/optional.rs
+++ b/cel/src/common/types/optional.rs
@@ -21,7 +21,7 @@ impl OptionalInternal {
 }
 
 impl Val for Optional {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::OPTIONAL_TYPE
     }
 

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -1,5 +1,5 @@
 use crate::common::traits::{self, Adder, Comparer, Sizer};
-use crate::common::types::{CelBool, CelBytes, CelDouble, CelInt, CelUInt, Type};
+use crate::common::types::{CelBool, CelBytes, CelDouble, CelInt, CelUInt, Kind, Type};
 #[cfg(feature = "chrono")]
 use crate::common::types::{CelDuration, CelTimestamp};
 use crate::common::value::{Downcast, Val};
@@ -31,7 +31,7 @@ impl Deref for String {
 }
 
 impl Val for String {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::STRING_TYPE
     }
 
@@ -188,28 +188,28 @@ fn matches<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Executio
 fn string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<String>, Box<dyn Val>> = match *arg.get_type() {
-        super::STRING_TYPE => arg.downcast::<String>(),
-        super::INT_TYPE => arg
+    let ret: Result<Box<String>, Box<dyn Val>> = match arg.get_type().kind() {
+        Kind::String => arg.downcast::<String>(),
+        Kind::Int => arg
             .downcast::<CelInt>()
             .map(|arg| Box::new(String::from(arg.to_string()))),
-        super::UINT_TYPE => arg
+        Kind::UInt => arg
             .downcast::<CelUInt>()
             .map(|arg| Box::new(String::from(arg.to_string()))),
-        super::DOUBLE_TYPE => arg
+        Kind::Double => arg
             .downcast::<CelDouble>()
             .map(|arg| Box::new(String::from(arg.to_string()))),
-        super::BYTES_TYPE => arg.downcast::<CelBytes>().map(|arg| {
+        Kind::Bytes => arg.downcast::<CelBytes>().map(|arg| {
             Box::new(String::from(
                 StdString::from_utf8_lossy(arg.inner()).as_ref(),
             ))
         }),
         #[cfg(feature = "chrono")]
-        super::TIMESTAMP_TYPE => arg
+        Kind::Timestamp => arg
             .downcast::<CelTimestamp>()
             .map(|ts| Box::new(String::from(ts.inner().to_rfc3339()))),
         #[cfg(feature = "chrono")]
-        super::DURATION_TYPE => arg
+        Kind::Duration => arg
             .downcast::<CelDuration>()
             .map(|arg| Box::new(String::from(crate::duration::format_duration(arg.inner())))),
         _ => Err(arg),
@@ -223,7 +223,7 @@ fn string<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Execution
     }
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "string",
         "string_to_string",

--- a/cel/src/common/types/struct.rs
+++ b/cel/src/common/types/struct.rs
@@ -11,14 +11,14 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct Struct {
-    r#type: Type<'static>,
+    r#type: Type,
     entries: BTreeMap<String, Arc<dyn Val>>,
 }
 
 impl Struct {
     pub fn new(name: String) -> Self {
         Self {
-            r#type: Type::new_struct_type(name.leak()),
+            r#type: Type::new_struct(name),
             entries: BTreeMap::default(),
         }
     }
@@ -41,13 +41,13 @@ impl Struct {
 }
 
 impl Val for Struct {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &self.r#type
     }
 
     fn clone_as_boxed(&self) -> Box<dyn Val> {
         Box::new(Self {
-            r#type: Type::new_struct_type(self.name().to_owned().leak()),
+            r#type: Type::new_struct(self.name().to_owned()),
             entries: self
                 .entries
                 .iter()
@@ -88,24 +88,7 @@ impl Indexer for Struct {
     }
 
     fn steal(self: Box<Self>, idx: &dyn Val) -> Result<Box<dyn Val>, crate::ExecutionError> {
-        // TODO: Can't implement this right now really, as we impl `Drop`, can't take ownership of
-        // the fields easily... let's see if this pattern sticks first, then we'll optimize the call
-        // to be no copy
         self.get(idx).map(Cow::into_owned)
-    }
-}
-
-impl Drop for Struct {
-    fn drop(&mut self) {
-        let name = self.r#type.name();
-
-        let ptr = name.as_ptr();
-        let len = name.len();
-
-        // SAFETY `Type` is not `Clone` and as such solely owned by this `Struct` being dropped
-        // We leak the name on `Struct::new` to get a &'static str, that we now no longer need
-        let name = unsafe { String::from_raw_parts(ptr as *mut u8, len, len) };
-        std::mem::drop(name);
     }
 }
 

--- a/cel/src/common/types/timestamp.rs
+++ b/cel/src/common/types/timestamp.rs
@@ -23,7 +23,7 @@ impl Timestamp {
 }
 
 impl Val for Timestamp {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::TIMESTAMP_TYPE
     }
 
@@ -249,7 +249,7 @@ fn timestamp<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, Execut
     })
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload(
         "timestamp",
         "string_to_timestamp",

--- a/cel/src/common/types/uint.rs
+++ b/cel/src/common/types/uint.rs
@@ -1,5 +1,5 @@
 use crate::common::traits::{Adder, Comparer, Divider, Modder, Multiplier, Subtractor};
-use crate::common::types::{CelDouble, CelInt, CelString, Type};
+use crate::common::types::{CelDouble, CelInt, CelString, Kind, Type};
 use crate::common::value::{Downcast, Val};
 use crate::{ExecutionError, Value};
 use std::borrow::Cow;
@@ -28,7 +28,7 @@ impl Deref for UInt {
 }
 
 impl Val for UInt {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &super::UINT_TYPE
     }
 
@@ -240,15 +240,15 @@ impl<'a> TryFrom<&'a dyn Val> for &'a u64 {
 fn uint<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
     let mut args = args;
     let arg = args.remove(0).into_owned();
-    let ret: Result<Box<UInt>, Box<dyn Val>> = match *arg.get_type() {
-        super::UINT_TYPE => arg.downcast::<UInt>(),
-        super::INT_TYPE => arg
+    let ret: Result<Box<UInt>, Box<dyn Val>> = match arg.get_type().kind() {
+        Kind::UInt => arg.downcast::<UInt>(),
+        Kind::Int => arg
             .downcast::<CelInt>()
             .map(|arg| Box::new(UInt::from(*arg.inner() as u64))),
-        super::DOUBLE_TYPE => arg
+        Kind::Double => arg
             .downcast::<CelDouble>()
             .map(|arg| Box::new(UInt::from(*arg.inner() as u64))),
-        super::STRING_TYPE => match arg.downcast::<CelString>() {
+        Kind::String => match arg.downcast::<CelString>() {
             Err(arg) => Err(arg),
             Ok(arg) => match arg.inner().parse::<u64>() {
                 Ok(arg) => Ok(Box::new(UInt::from(arg))),
@@ -272,7 +272,7 @@ fn uint<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionEr
     }
 }
 
-pub(crate) fn stdlib(env: &mut crate::Env<'_>) {
+pub(crate) fn stdlib(env: &mut crate::Env) {
     env.add_overload("uint", "uint64_to_uint64", vec![super::UINT_TYPE], uint)
         .expect("Must be unique id");
     env.add_overload("uint", "int64_to_uint64", vec![super::INT_TYPE], uint)

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -7,7 +7,7 @@ use std::any::Any;
 use std::fmt::Debug;
 
 pub trait Val: Any + Debug + Send + Sync {
-    fn get_type<'a>(&self) -> &Type<'a>;
+    fn get_type(&self) -> &Type;
 
     fn as_adder(&self) -> Option<&dyn Adder> {
         None

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -37,7 +37,7 @@ pub enum Context<'a> {
         functions: FunctionRegistry,
         variables: BTreeMap<String, Box<dyn Val>>,
         resolver: Option<&'a dyn VariableResolver>,
-        env: Arc<Env<'a>>,
+        env: Arc<Env>,
     },
     Child {
         parent: &'a Context<'a>,
@@ -153,7 +153,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub(crate) fn env(&self) -> &Env<'_> {
+    pub(crate) fn env(&self) -> &Env {
         match self {
             Context::Root { env, .. } => env.as_ref(),
             Context::Child { parent, .. } => parent.env(),
@@ -213,7 +213,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub fn with_env(env: Arc<Env<'a>>) -> Self {
+    pub fn with_env(env: Arc<Env>) -> Self {
         Context::Root {
             env,
             variables: Default::default(),

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -128,15 +128,14 @@ impl StructDef {
     }
 
     pub fn add_field(self, field: String, t: Type) -> Self {
-        self.add_field_with_default(field, t, None)
+        self.insert_field(field, t, None)
     }
 
-    pub fn add_field_with_default(
-        self,
-        field: String,
-        t: Type,
-        default: Option<Box<dyn Val>>,
-    ) -> Self {
+    pub fn add_field_with_default(self, field: String, default: Box<dyn Val>) -> Self {
+        self.insert_field(field, default.get_type().to_owned(), Some(default))
+    }
+
+    fn insert_field(self, field: String, t: Type, default: Option<Box<dyn Val>>) -> Self {
         let mut def = self;
         def.fields.insert(field.clone(), t);
         if let Some(default) = default {

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -15,13 +15,13 @@ use std::{
 };
 
 #[derive(Default)]
-pub struct Env<'a> {
-    functions: BTreeMap<String, FunctionDecl<'a>>,
-    structs: BTreeMap<String, StructDef<'a>>,
+pub struct Env {
+    functions: BTreeMap<String, FunctionDecl>,
+    structs: BTreeMap<String, StructDef>,
 }
 
-impl<'a> Env<'a> {
-    pub fn stdlib() -> Env<'a> {
+impl Env {
+    pub fn stdlib() -> Env {
         let mut env = Env::default();
         types::bytes::stdlib(&mut env);
         types::double::stdlib(&mut env);
@@ -44,7 +44,7 @@ impl<'a> Env<'a> {
         &mut self,
         name: &str,
         id: &str,
-        args: Vec<types::Type<'a>>,
+        args: Vec<types::Type>,
         op: Function,
     ) -> Result<(), ()> {
         match self.functions.entry(name.to_owned()) {
@@ -74,8 +74,8 @@ impl<'a> Env<'a> {
         &mut self,
         name: &str,
         id: &str,
-        target: Type<'a>,
-        args: Vec<types::Type<'a>>,
+        target: Type,
+        args: Vec<types::Type>,
         op: Function,
     ) -> Result<(), ()> {
         let mut args = args;
@@ -102,23 +102,23 @@ impl<'a> Env<'a> {
         }
     }
 
-    pub fn add_struct(&mut self, def: StructDef<'a>) {
+    pub fn add_struct(&mut self, def: StructDef) {
         self.structs.insert(def.name.clone(), def);
     }
 
     #[cfg(feature = "structs")]
-    pub(crate) fn find_struct(&self, name: &str) -> Option<&StructDef<'a>> {
+    pub(crate) fn find_struct(&self, name: &str) -> Option<&StructDef> {
         self.structs.get(name)
     }
 }
 
-pub struct StructDef<'a> {
+pub struct StructDef {
     name: String,
-    fields: BTreeMap<String, Type<'a>>,
+    fields: BTreeMap<String, Type>,
     defaults: BTreeMap<String, Box<dyn Val>>,
 }
 
-impl<'a> StructDef<'a> {
+impl StructDef {
     pub fn new(name: String) -> Self {
         Self {
             name,
@@ -127,14 +127,14 @@ impl<'a> StructDef<'a> {
         }
     }
 
-    pub fn add_field(self, field: String, t: Type<'a>) -> Self {
+    pub fn add_field(self, field: String, t: Type) -> Self {
         self.add_field_with_default(field, t, None)
     }
 
     pub fn add_field_with_default(
         self,
         field: String,
-        t: Type<'a>,
+        t: Type,
         default: Option<Box<dyn Val>>,
     ) -> Self {
         let mut def = self;

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -410,7 +410,7 @@ impl dyn Opaque {
 }
 
 struct OpaqueVal {
-    r#type: Type<'static>,
+    r#type: Type,
     val: Arc<dyn Opaque>,
 }
 
@@ -421,7 +421,7 @@ impl Debug for OpaqueVal {
 }
 
 impl Val for OpaqueVal {
-    fn get_type<'a>(&self) -> &Type<'a> {
+    fn get_type(&self) -> &Type {
         &self.r#type
     }
 
@@ -438,7 +438,7 @@ impl Val for OpaqueVal {
 
     fn clone_as_boxed(&self) -> Box<dyn Val> {
         Box::new(Self {
-            r#type: Type::new_opaque_type(self.val.runtime_type_name().to_owned().leak()),
+            r#type: Type::new_opaque(self.val.runtime_type_name().to_owned()),
             val: self.val.clone(),
         })
     }
@@ -447,27 +447,13 @@ impl Val for OpaqueVal {
 impl OpaqueVal {
     fn new(val: Arc<dyn Opaque>) -> Self {
         Self {
-            r#type: Type::new_opaque_type(val.runtime_type_name().to_owned().leak()),
+            r#type: Type::new_opaque(val.runtime_type_name().to_owned()),
             val,
         }
     }
 
     fn clone_inner(&self) -> Arc<dyn Opaque> {
         self.val.clone()
-    }
-}
-
-impl Drop for OpaqueVal {
-    fn drop(&mut self) {
-        let name = self.r#type.name();
-
-        let ptr = name.as_ptr();
-        let len = name.len();
-
-        // SAFETY `Type` is not `Clone` and is solely owned by this
-        // We leak the name on `OpaqueVal::new` to get a &'static str, that we now no longer need
-        let name = unsafe { String::from_raw_parts(ptr as *mut u8, len, len) };
-        std::mem::drop(name);
     }
 }
 
@@ -867,30 +853,30 @@ impl From<Value> for ResolveResult {
 impl TryFrom<&dyn Val> for Value {
     type Error = ExecutionError;
     fn try_from(v: &dyn Val) -> Result<Self, Self::Error> {
-        match *v.get_type() {
-            BOOL_TYPE => Ok(Value::Bool(*v.downcast_ref::<CelBool>().unwrap().inner())),
-            INT_TYPE => Ok(Value::Int(*v.downcast_ref::<CelInt>().unwrap().inner())),
-            UINT_TYPE => Ok(Value::UInt(*v.downcast_ref::<CelUInt>().unwrap().inner())),
-            DOUBLE_TYPE => Ok(Value::Float(
+        match v.get_type().kind() {
+            Kind::Boolean => Ok(Value::Bool(*v.downcast_ref::<CelBool>().unwrap().inner())),
+            Kind::Int => Ok(Value::Int(*v.downcast_ref::<CelInt>().unwrap().inner())),
+            Kind::UInt => Ok(Value::UInt(*v.downcast_ref::<CelUInt>().unwrap().inner())),
+            Kind::Double => Ok(Value::Float(
                 *v.downcast_ref::<CelDouble>().unwrap().inner(),
             )),
-            STRING_TYPE => Ok(Value::String(Arc::new(
+            Kind::String => Ok(Value::String(Arc::new(
                 v.downcast_ref::<CelString>().unwrap().inner().to_string(),
             ))),
-            NULL_TYPE => Ok(Value::Null),
-            BYTES_TYPE => Ok(Value::Bytes(Arc::new(
+            Kind::NullType => Ok(Value::Null),
+            Kind::Bytes => Ok(Value::Bytes(Arc::new(
                 v.downcast_ref::<CelBytes>().unwrap().inner().to_vec(),
             ))),
             #[cfg(feature = "chrono")]
-            DURATION_TYPE => Ok(Value::Duration(
+            Kind::Duration => Ok(Value::Duration(
                 *v.downcast_ref::<CelDuration>().unwrap().inner(),
             )),
             #[cfg(feature = "chrono")]
-            TIMESTAMP_TYPE => {
+            Kind::Timestamp => {
                 let ts = v.downcast_ref::<CelTimestamp>().unwrap().inner();
                 Ok(Value::Timestamp(*ts))
             }
-            LIST_TYPE => {
+            Kind::List => {
                 let list = v.downcast_ref::<CelList>().unwrap().inner();
                 Ok(Value::List(Arc::new(
                     list.iter()
@@ -898,7 +884,7 @@ impl TryFrom<&dyn Val> for Value {
                         .collect(),
                 )))
             }
-            MAP_TYPE => {
+            Kind::Map => {
                 let map = v.downcast_ref::<CelMap>().unwrap().inner();
                 Ok(Value::Map(Map {
                     map: Arc::new(
@@ -913,7 +899,7 @@ impl TryFrom<&dyn Val> for Value {
                     ),
                 }))
             }
-            OPTIONAL_TYPE => Ok(Value::Opaque(match v.downcast_ref::<CelOptional>() {
+            Kind::Opaque => Ok(Value::Opaque(match v.downcast_ref::<CelOptional>() {
                 None => v.downcast_ref::<OpaqueVal>().unwrap().clone_inner(),
                 Some(opt) => {
                     let opt: Option<Result<Value, _>> = opt.option().map(|v| v.try_into());
@@ -1125,8 +1111,8 @@ impl Value {
                         operators::OPT_SELECT => {
                             let operand = Value::resolve_val(&call.args[0], ctx)?;
                             let field_literal = Value::resolve_val(&call.args[1], ctx)?;
-                            let field = match *field_literal.get_type() {
-                                STRING_TYPE => field_literal
+                            let field = match field_literal.get_type().kind() {
+                                Kind::String => field_literal
                                     .downcast_ref::<CelString>()
                                     .expect("field must be string"),
                                 _ => {
@@ -1399,8 +1385,8 @@ impl Value {
             Expr::Select(select) => {
                 let left = Value::resolve_val(select.operand.deref(), ctx)?;
                 let key: CelString = select.field.as_str().into();
-                match *left.get_type() {
-                    MAP_TYPE => {
+                match left.get_type().kind() {
+                    Kind::Map => {
                         if select.test {
                             Ok(bool(
                                 left.as_container()

--- a/cel/src/objects.rs
+++ b/cel/src/objects.rs
@@ -2683,11 +2683,7 @@ mod tests {
             env.add_struct(
                 StructDef::new(String::from("cel.MyStruct"))
                     .add_field("some".into(), types::STRING_TYPE)
-                    .add_field_with_default(
-                        "here".into(),
-                        types::STRING_TYPE,
-                        Some(Box::new(CelString::from("yes"))),
-                    ),
+                    .add_field_with_default("here".into(), Box::new(CelString::from("yes"))),
             );
             let program = Program::compile("cel.MyStruct { some: 'value' }.here").unwrap();
             let result = program.execute(&Context::with_env(env.into()));
@@ -2700,11 +2696,7 @@ mod tests {
             env.add_struct(
                 StructDef::new(String::from("cel.MyStruct"))
                     .add_field("some".into(), types::STRING_TYPE)
-                    .add_field_with_default(
-                        "here".into(),
-                        types::STRING_TYPE,
-                        Some(Box::new(CelString::from("yes"))),
-                    ),
+                    .add_field_with_default("here".into(), Box::new(CelString::from("yes"))),
             );
             let program =
                 Program::compile("cel.MyStruct { some: 'value', here: 'totally' }.here").unwrap();


### PR DESCRIPTION
... This builds on #286, it's mostly a huge refactoring to

```rust
pub struct Type {
    kind: Kind,
    parameters: Cow<'static, [Cow<'static, Type>]>,
    runtime_type_name: Cow<'static, str>,
    trait_mask: TraitSet,
} 
```

which gets rid of the lifetime on `Type<'a>`, and makes this all way more digestible I hope. It was mostly driven by that second commit, which now lets us "clone" (`impl ToOwned for Type`) while keeping `Type` relatively cheap (at least for the stdlib types). 