### PR TITLE
Overload optional

### DIFF
--- a/cel/src/common/traits.rs
+++ b/cel/src/common/traits.rs
@@ -100,6 +100,10 @@ pub trait Subtractor {
     fn sub<'a>(&'a self, _rhs: &'_ dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;
 }
 
+pub trait Zeroer {
+    fn is_zero_value(&self) -> bool;
+}
+
 pub trait Indexer {
     fn get<'a>(&'a self, _idx: &dyn Val) -> Result<Cow<'a, dyn Val>, ExecutionError>;
 

--- a/cel/src/common/types/bool.rs
+++ b/cel/src/common/types/bool.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Comparer, Negator};
+use crate::common::traits::{Comparer, Negator, Zeroer};
 use crate::common::types::Type;
 use crate::common::value::Val;
 use crate::ExecutionError;
@@ -42,6 +42,10 @@ impl Val for Bool {
         Some(self)
     }
 
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
+        Some(self)
+    }
+
     fn equals(&self, other: &dyn Val) -> bool {
         other.downcast_ref::<Self>().is_some_and(|a| self.0 == a.0)
     }
@@ -64,6 +68,12 @@ impl Comparer for Bool {
 impl Negator for Bool {
     fn negate(&self) -> Result<Box<dyn Val>, ExecutionError> {
         Ok(Box::new(self.negate()))
+    }
+}
+
+impl Zeroer for Bool {
+    fn is_zero_value(&self) -> bool {
+        !self.0
     }
 }
 

--- a/cel/src/common/types/bytes.rs
+++ b/cel/src/common/types/bytes.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::Sizer;
+use crate::common::traits::{Sizer, Zeroer};
 use crate::common::types::{CelInt, CelString, Type};
 use crate::common::value::{Downcast, Val};
 use crate::Value;
@@ -45,6 +45,10 @@ impl Val for Bytes {
         Some(self)
     }
 
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
+        Some(self)
+    }
+
     fn equals(&self, other: &dyn Val) -> bool {
         other
             .downcast_ref::<Self>()
@@ -85,6 +89,12 @@ impl Comparer for Bytes {
 impl Sizer for Bytes {
     fn size(&self) -> CelInt {
         (self.inner().len() as i64).into()
+    }
+}
+
+impl Zeroer for Bytes {
+    fn is_zero_value(&self) -> bool {
+        self.inner().is_empty()
     }
 }
 

--- a/cel/src/common/types/double.rs
+++ b/cel/src/common/types/double.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Adder, Comparer, Divider, Multiplier, Negator, Subtractor};
+use crate::common::traits::{Adder, Comparer, Divider, Multiplier, Negator, Subtractor, Zeroer};
 use crate::common::types::{CelInt, CelString, CelUInt, Kind, Type};
 use crate::common::value::{Downcast, Val};
 use crate::{ExecutionError, Value};
@@ -53,6 +53,10 @@ impl Val for Double {
     }
 
     fn as_subtractor(&self) -> Option<&dyn Subtractor> {
+        Some(self)
+    }
+
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
         Some(self)
     }
 
@@ -149,6 +153,12 @@ impl Subtractor for Double {
                 rhs.try_into().unwrap_or(Value::Null),
             ))
         }
+    }
+}
+
+impl Zeroer for Double {
+    fn is_zero_value(&self) -> bool {
+        self.0 == 0.0
     }
 }
 

--- a/cel/src/common/types/duration.rs
+++ b/cel/src/common/types/duration.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Adder, Comparer, Subtractor};
+use crate::common::traits::{Adder, Comparer, Subtractor, Zeroer};
 use crate::common::types::{CelInt, CelString, Type};
 use crate::common::value::Val;
 use crate::{ExecutionError, Value};
@@ -40,6 +40,10 @@ impl Val for Duration {
     }
 
     fn as_subtractor(&self) -> Option<&dyn Subtractor> {
+        Some(self)
+    }
+
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
         Some(self)
     }
 
@@ -95,6 +99,12 @@ impl Subtractor for Duration {
         } else {
             Err(ExecutionError::NoSuchOverload)
         }
+    }
+}
+
+impl Zeroer for Duration {
+    fn is_zero_value(&self) -> bool {
+        self.0.is_zero()
     }
 }
 

--- a/cel/src/common/types/int.rs
+++ b/cel/src/common/types/int.rs
@@ -61,6 +61,10 @@ impl Val for Int {
         Some(self)
     }
 
+    fn as_zeroer(&self) -> Option<&dyn traits::Zeroer> {
+        Some(self)
+    }
+
     fn equals(&self, other: &dyn Val) -> bool {
         self.compare(other)
             .map(|r| r == Ordering::Equal)
@@ -179,6 +183,12 @@ impl traits::Subtractor for Int {
         } else {
             Err(ExecutionError::NoSuchOverload)
         }
+    }
+}
+
+impl traits::Zeroer for Int {
+    fn is_zero_value(&self) -> bool {
+        self.0 == 0
     }
 }
 

--- a/cel/src/common/types/list.rs
+++ b/cel/src/common/types/list.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Adder, Container, Indexer, Iterable, Sizer};
+use crate::common::traits::{Adder, Container, Indexer, Iterable, Sizer, Zeroer};
 use crate::common::types::{CelInt, CelUInt, Kind, Type};
 use crate::common::value::Val;
 use crate::common::{traits, types};
@@ -62,6 +62,10 @@ impl Val for DefaultList {
     }
 
     fn as_sizer(&self) -> Option<&dyn Sizer> {
+        Some(self)
+    }
+
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
         Some(self)
     }
 
@@ -183,6 +187,12 @@ impl Iterable for DefaultList {
 impl Sizer for DefaultList {
     fn size(&self) -> CelInt {
         (self.inner().len() as i64).into()
+    }
+}
+
+impl Zeroer for DefaultList {
+    fn is_zero_value(&self) -> bool {
+        self.inner().is_empty()
     }
 }
 

--- a/cel/src/common/types/map.rs
+++ b/cel/src/common/types/map.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Container, Indexer, Iterable, Sizer};
+use crate::common::traits::{Container, Indexer, Iterable, Sizer, Zeroer};
 use crate::common::types::{CelBool, CelInt, CelString, CelUInt, Kind, Type};
 use crate::common::value::Val;
 use crate::common::{traits, types};
@@ -55,6 +55,10 @@ impl Val for DefaultMap {
     }
 
     fn as_sizer(&self) -> Option<&dyn Sizer> {
+        Some(self)
+    }
+
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
         Some(self)
     }
 
@@ -142,6 +146,12 @@ impl Iterable for DefaultMap {
 impl Sizer for DefaultMap {
     fn size(&self) -> CelInt {
         (self.inner().len() as i64).into()
+    }
+}
+
+impl Zeroer for DefaultMap {
+    fn is_zero_value(&self) -> bool {
+        self.inner().is_empty()
     }
 }
 

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod int;
 pub(crate) mod list;
 pub(crate) mod map;
 mod null;
-mod optional;
+pub(crate) mod optional;
 pub(crate) mod string;
 #[cfg(feature = "structs")]
 pub(crate) mod r#struct;
@@ -92,8 +92,11 @@ impl Type {
         } else {
             match self.kind() {
                 Kind::Dyn => true,
-                Kind::Opaque => self.parameters.first().is_some_and(|t| t.is_assignable(val)),
-                _ => false
+                Kind::Opaque => self
+                    .parameters
+                    .first()
+                    .is_some_and(|t| t.is_assignable(val)),
+                _ => false,
             }
         }
     }

--- a/cel/src/common/types/mod.rs
+++ b/cel/src/common/types/mod.rs
@@ -87,7 +87,15 @@ impl ToOwned for Type {
 
 impl Type {
     pub fn is_assignable(&self, val: &dyn Val) -> bool {
-        self == val.get_type()
+        if self == val.get_type() {
+            true
+        } else {
+            match self.kind() {
+                Kind::Dyn => true,
+                Kind::Opaque => self.parameters.first().is_some_and(|t| t.is_assignable(val)),
+                _ => false
+            }
+        }
     }
 }
 
@@ -203,7 +211,7 @@ pub const NULL_TYPE: Type = {
 
 pub const OPTIONAL_TYPE: Type = Type {
     kind: Kind::Opaque,
-    parameters: Cow::Borrowed(&[]),
+    parameters: Cow::Borrowed(&[Cow::Borrowed(&DYN_TYPE)]),
     runtime_type_name: Cow::Borrowed("optional_type"),
     trait_mask: 0,
 };

--- a/cel/src/common/types/null.rs
+++ b/cel/src/common/types/null.rs
@@ -1,3 +1,4 @@
+use crate::common::traits::Zeroer;
 use crate::common::types::Type;
 use crate::common::value::Val;
 
@@ -13,7 +14,17 @@ impl Val for Null {
         other.downcast_ref::<Null>().is_some()
     }
 
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
+        Some(self)
+    }
+
     fn clone_as_boxed(&self) -> Box<dyn Val> {
         Box::new(Null)
+    }
+}
+
+impl Zeroer for Null {
+    fn is_zero_value(&self) -> bool {
+        true
     }
 }

--- a/cel/src/common/types/optional.rs
+++ b/cel/src/common/types/optional.rs
@@ -1,5 +1,8 @@
-use crate::common::types::Type;
+use crate::common::traits::Zeroer;
+use crate::common::types::{self, CelBool, Type, OPTIONAL_TYPE};
 use crate::common::value::Val;
+use crate::ExecutionError;
+use std::borrow::Cow;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -101,6 +104,128 @@ impl From<Optional> for Option<Arc<dyn Val>> {
             OptionalInternal::Box(b) => Arc::from(b),
         })
     }
+}
+
+fn optional_none<'a>(_args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    Ok(Cow::<dyn Val>::Owned(Box::new(Optional::none())))
+}
+
+fn optional_of<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let value = args.remove(0);
+    Ok(Cow::<dyn Val>::Owned(Box::new(Optional::of(
+        value.into_owned(),
+    ))))
+}
+
+fn optional_of_non_zero_value<'a>(
+    args: Vec<Cow<'a, dyn Val>>,
+) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    match args[0].as_zeroer().is_some_and(Zeroer::is_zero_value) {
+        true => optional_none(args),
+        false => optional_of(args),
+    }
+}
+
+fn optional_value<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    // TODO: This can be optimized to avoid cloning and "just" pass the `Cow`
+    // but we either need to deal with the `Arc` case or wait until that's all ripped out!
+    let mut args = args;
+    args.remove(0)
+        .downcast_ref::<Optional>()
+        .expect("must be `CelOptional`")
+        .option()
+        .map(|v| Cow::Owned(v.to_owned()))
+        .ok_or_else(|| ExecutionError::function_error("value", "optional.none() dereference"))
+}
+
+fn optional_has_value<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    super::unary_fn(args, OPTIONAL_TYPE, |opt: &Optional| {
+        Ok(Box::new(CelBool::from(opt.option().is_some())))
+    })
+}
+
+fn optional_or_optional<'a>(
+    args: Vec<Cow<'a, dyn Val>>,
+) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    let mut args = args;
+    let other = args.remove(1);
+    let this = args.remove(0);
+    if this
+        .downcast_ref::<Optional>()
+        .expect("Must be an `Optional`")
+        .option()
+        .is_some()
+    {
+        Ok(this)
+    } else {
+        Ok(other)
+    }
+}
+
+fn optional_or_value<'a>(args: Vec<Cow<'a, dyn Val>>) -> Result<Cow<'a, dyn Val>, ExecutionError> {
+    // TODO: This can be optimized to avoid cloning and "just" pass the `Cow`
+    // but we either need to deal with the `Arc` case or wait until that's all ripped out!
+    let mut args = args;
+    let other = args.remove(1);
+    Ok(args
+        .remove(0)
+        .downcast_ref::<Optional>()
+        .expect("must be `CelOptional`")
+        .option()
+        .map(|v| Cow::Owned(v.to_owned()))
+        .unwrap_or(other))
+}
+
+pub(crate) fn stdlib(env: &mut crate::Env) {
+    env.add_overload("optional.none", "optional_none", vec![], optional_none)
+        .expect("Must be unique");
+    env.add_overload(
+        "optional.of",
+        "optional_of",
+        vec![types::DYN_TYPE],
+        optional_of,
+    )
+    .expect("Must be unique");
+    env.add_overload(
+        "optional.ofNonZeroValue",
+        "optional_ofNonZeroValue",
+        vec![types::DYN_TYPE],
+        optional_of_non_zero_value,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "value",
+        "optional_value",
+        OPTIONAL_TYPE,
+        vec![],
+        optional_value,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "hasValue",
+        "optional_has_value",
+        OPTIONAL_TYPE,
+        vec![],
+        optional_has_value,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "or",
+        "optional_or_optional",
+        OPTIONAL_TYPE,
+        vec![OPTIONAL_TYPE],
+        optional_or_optional,
+    )
+    .expect("Must be unique");
+    env.add_member_overload(
+        "orValue",
+        "optional_or_value",
+        OPTIONAL_TYPE,
+        vec![types::DYN_TYPE],
+        optional_or_value,
+    )
+    .expect("Must be unique");
 }
 
 #[cfg(test)]

--- a/cel/src/common/types/optional.rs
+++ b/cel/src/common/types/optional.rs
@@ -102,3 +102,16 @@ impl From<Optional> for Option<Arc<dyn Val>> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::common::types::{self, CelInt, CelString};
+
+    #[test]
+    fn is_assignable() {
+        let s = CelString::from("foo");
+        assert!(types::OPTIONAL_TYPE.is_assignable(&s));
+        let i = CelInt::from(42);
+        assert!(types::OPTIONAL_TYPE.is_assignable(&i));
+    }
+}

--- a/cel/src/common/types/string.rs
+++ b/cel/src/common/types/string.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{self, Adder, Comparer, Sizer};
+use crate::common::traits::{self, Adder, Comparer, Sizer, Zeroer};
 use crate::common::types::{CelBool, CelBytes, CelDouble, CelInt, CelUInt, Kind, Type};
 #[cfg(feature = "chrono")]
 use crate::common::types::{CelDuration, CelTimestamp};
@@ -47,6 +47,10 @@ impl Val for String {
         Some(self)
     }
 
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
+        Some(self)
+    }
+
     fn equals(&self, other: &dyn Val) -> bool {
         other
             .downcast_ref::<Self>()
@@ -88,6 +92,12 @@ impl Comparer for String {
 impl Sizer for String {
     fn size(&self) -> CelInt {
         (self.inner().len() as i64).into()
+    }
+}
+
+impl Zeroer for String {
+    fn is_zero_value(&self) -> bool {
+        self.inner().is_empty()
     }
 }
 

--- a/cel/src/common/types/struct.rs
+++ b/cel/src/common/types/struct.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::BTreeMap, ops::Deref, sync::Arc};
 
 use crate::{
     common::{
-        traits::Indexer,
+        traits::{Indexer, Zeroer},
         types::{CelString, Type},
         value::Val,
     },
@@ -64,6 +64,10 @@ impl Val for Struct {
         Some(self)
     }
 
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
+        Some(self)
+    }
+
     fn equals(&self, other: &dyn Val) -> bool {
         other
             .downcast_ref::<Struct>()
@@ -89,6 +93,12 @@ impl Indexer for Struct {
 
     fn steal(self: Box<Self>, idx: &dyn Val) -> Result<Box<dyn Val>, crate::ExecutionError> {
         self.get(idx).map(Cow::into_owned)
+    }
+}
+
+impl Zeroer for Struct {
+    fn is_zero_value(&self) -> bool {
+        self.entries.is_empty()
     }
 }
 

--- a/cel/src/common/types/timestamp.rs
+++ b/cel/src/common/types/timestamp.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Adder, Comparer, Subtractor};
+use crate::common::traits::{Adder, Comparer, Subtractor, Zeroer};
 use crate::common::types::{CelDuration, CelInt, CelString, Type};
 use crate::common::value::Val;
 use crate::{ExecutionError, Value};
@@ -36,6 +36,10 @@ impl Val for Timestamp {
     }
 
     fn as_subtractor(&self) -> Option<&dyn Subtractor> {
+        Some(self)
+    }
+
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
         Some(self)
     }
 
@@ -131,6 +135,12 @@ impl Subtractor for Timestamp {
                 rhs.try_into().unwrap_or(Value::Null),
             ))
         }
+    }
+}
+
+impl Zeroer for Timestamp {
+    fn is_zero_value(&self) -> bool {
+        self.0.timestamp_nanos_opt().is_some_and(|ns| ns == 0)
     }
 }
 

--- a/cel/src/common/types/uint.rs
+++ b/cel/src/common/types/uint.rs
@@ -1,4 +1,4 @@
-use crate::common::traits::{Adder, Comparer, Divider, Modder, Multiplier, Subtractor};
+use crate::common::traits::{Adder, Comparer, Divider, Modder, Multiplier, Subtractor, Zeroer};
 use crate::common::types::{CelDouble, CelInt, CelString, Kind, Type};
 use crate::common::value::{Downcast, Val};
 use crate::{ExecutionError, Value};
@@ -53,6 +53,10 @@ impl Val for UInt {
     }
 
     fn as_subtractor(&self) -> Option<&dyn Subtractor> {
+        Some(self)
+    }
+
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
         Some(self)
     }
 
@@ -201,6 +205,12 @@ impl Subtractor for UInt {
                 rhs.try_into().unwrap_or(Value::Null),
             ))
         }
+    }
+}
+
+impl Zeroer for UInt {
+    fn is_zero_value(&self) -> bool {
+        self.0 == 0
     }
 }
 

--- a/cel/src/common/value.rs
+++ b/cel/src/common/value.rs
@@ -1,6 +1,6 @@
 use crate::common::traits::{
     Adder, Comparer, Container, Divider, Indexer, Iterable, Modder, Multiplier, Negator, Sizer,
-    Subtractor,
+    Subtractor, Zeroer,
 };
 use crate::common::types::Type;
 use std::any::Any;
@@ -54,6 +54,10 @@ pub trait Val: Any + Debug + Send + Sync {
     }
 
     fn as_subtractor(&self) -> Option<&dyn Subtractor> {
+        None
+    }
+
+    fn as_zeroer(&self) -> Option<&dyn Zeroer> {
         None
     }
 

--- a/cel/src/context.rs
+++ b/cel/src/context.rs
@@ -2,7 +2,7 @@ use crate::common::value::Val;
 use crate::magic::{Function, FunctionRegistry, IntoFunction};
 use crate::objects::{TryIntoValue, Value};
 use crate::parser::Expression;
-use crate::{functions, Env, ExecutionError};
+use crate::{Env, ExecutionError};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -225,25 +225,12 @@ impl<'a> Context<'a> {
 
 impl Default for Context<'_> {
     fn default() -> Self {
-        let mut ctx = Context::Root {
+        Context::Root {
             env: Arc::new(Env::stdlib()),
             variables: Default::default(),
             functions: Default::default(),
             resolver: None,
-        };
-
-        // Optional
-        ctx.add_function("optional.none", functions::optional_none);
-        ctx.add_function("optional.of", functions::optional_of);
-        ctx.add_function(
-            "optional.ofNonZeroValue",
-            functions::optional_of_non_zero_value,
-        );
-        ctx.add_function("value", functions::optional_value);
-        ctx.add_function("hasValue", functions::optional_has_value);
-        ctx.add_function("or", functions::optional_or_optional);
-        ctx.add_function("orValue", functions::optional_or_value);
-        ctx
+        }
     }
 }
 

--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -28,6 +28,7 @@ impl Env {
         types::int::stdlib(&mut env);
         types::list::stdlib(&mut env);
         types::map::stdlib(&mut env);
+        types::optional::stdlib(&mut env);
         types::string::stdlib(&mut env);
         types::uint::stdlib(&mut env);
 


### PR DESCRIPTION
this wraps up the removal of all `add_function` in the `Context::default()`, all are now resolved and implemented using proper overloads