### PR TITLE
Update structs feature gating and expose StructDef

### DIFF
--- a/cel/src/env.rs
+++ b/cel/src/env.rs
@@ -17,6 +17,7 @@ use std::{
 #[derive(Default)]
 pub struct Env {
     functions: BTreeMap<String, FunctionDecl>,
+    #[cfg(feature = "structs")]
     structs: BTreeMap<String, StructDef>,
 }
 
@@ -103,6 +104,7 @@ impl Env {
         }
     }
 
+    #[cfg(feature = "structs")]
     pub fn add_struct(&mut self, def: StructDef) {
         self.structs.insert(def.name.clone(), def);
     }
@@ -113,12 +115,14 @@ impl Env {
     }
 }
 
+#[cfg(feature = "structs")]
 pub struct StructDef {
     name: String,
     fields: BTreeMap<String, Type>,
     defaults: BTreeMap<String, Box<dyn Val>>,
 }
 
+#[cfg(feature = "structs")]
 impl StructDef {
     pub fn new(name: String) -> Self {
         Self {
@@ -145,7 +149,6 @@ impl StructDef {
         def
     }
 
-    #[cfg(feature = "structs")]
     pub(crate) fn new_struct(
         &self,
         fields: BTreeMap<String, std::borrow::Cow<dyn Val>>,

--- a/cel/src/lib.rs
+++ b/cel/src/lib.rs
@@ -29,6 +29,8 @@ mod duration;
 pub use ser::{Duration, Timestamp};
 
 pub use env::Env;
+#[cfg(feature = "structs")]
+pub use env::StructDef;
 
 mod ser;
 pub use ser::to_value;


### PR DESCRIPTION
Trying to leverage `add_struct` with the `structs` feature but `StructDef` is in the private module - re-exporting for the feature flag